### PR TITLE
feat: reuse single watcher instance for web

### DIFF
--- a/src/gengowatcher/main.py
+++ b/src/gengowatcher/main.py
@@ -154,10 +154,13 @@ def main():
     web_thread = None
     if args.web or args.web_only:
         try:
-            from .web import run_web_server
+            from .web import run_web_server, attach_external_components
 
             def start_web_server():
                 print(f"Starting web server on http://127.0.0.1:{args.web_port}")
+                # Reuse the existing watcher so the web layer and TUI
+                # share a single monitoring instance.
+                attach_external_components(config, state, watcher, log)
                 run_web_server(host="127.0.0.1", port=args.web_port)
 
             web_thread = threading.Thread(

--- a/src/gengowatcher/web.py
+++ b/src/gengowatcher/web.py
@@ -55,6 +55,27 @@ class APIAuthenticator:
 # Global authenticator instance
 authenticator = APIAuthenticator()
 
+# Optional external components supplied by the TUI so we can
+# reuse an existing watcher instance instead of starting a
+# second one inside the web process.
+_external_components: Optional[dict] = None
+
+
+def attach_external_components(config: AppConfig, state: AppState, watcher: GengoWatcher, logger: logging.Logger) -> None:
+    """Attach pre-initialized components for reuse by the web API.
+
+    When the TUI starts the web server, it can pass its existing
+    config/state/watcher/logger so the web layer does not spawn
+    a second independent watcher.
+    """
+    global _external_components
+    _external_components = {
+        "config": config,
+        "state": state,
+        "watcher": watcher,
+        "logger": logger,
+    }
+
 
 # Pydantic models for API responses
 class JobEntry(BaseModel):
@@ -162,7 +183,7 @@ class PaginationParams(BaseModel):
 class WebAPI:
     """Web API wrapper for GengoWatcher that maintains thread safety."""
 
-    def __init__(self, config: AppConfig, state: AppState, logger: logging.Logger):
+    def __init__(self, config: AppConfig, state: AppState, logger: logging.Logger, watcher: Optional[GengoWatcher] = None):
         """Initialize the WebAPI instance.
 
         Creates a separate GengoWatcher instance for the web API to avoid conflicts
@@ -177,9 +198,14 @@ class WebAPI:
         self.state = state
         self.logger = logger
 
-        # Create a separate watcher instance for web API
-        # This allows web UI to run alongside TUI without conflicts
-        self.watcher = GengoWatcher(config, state, logger)
+        # Use provided watcher if available; otherwise create our own
+        if watcher is not None:
+            self.watcher = watcher
+            self.logger.info("WebAPI reusing existing watcher instance")
+        else:
+            # Create a separate watcher instance for web API
+            # This allows web UI to run alongside TUI without conflicts
+            self.watcher = GengoWatcher(config, state, logger)
 
         # Thread safety for shared state access
         self._status_lock = threading.RLock()  # Reentrant lock for better safety
@@ -187,13 +213,16 @@ class WebAPI:
         self._connections_lock = threading.RLock()
         self._jobs_lock = threading.RLock()
 
-        # Start the watcher in a separate thread
-        self.watcher_thread = threading.Thread(
-            target=self.watcher.run, daemon=True, name="WebWatcherThread"
-        )
-        self.watcher_thread.start()
-
-        self.logger.info("WebAPI initialized and watcher thread started")
+        # Start the watcher in a separate thread only if we own it
+        self.watcher_thread = None
+        if watcher is None:
+            self.watcher_thread = threading.Thread(
+                target=self.watcher.run, daemon=True, name="WebWatcherThread"
+            )
+            self.watcher_thread.start()
+            self.logger.info("WebAPI initialized and watcher thread started")
+        else:
+            self.logger.info("WebAPI attached to existing watcher thread")
 
     def get_status(self) -> WatcherStatus:
         """Get current watcher status."""
@@ -547,7 +576,9 @@ class WebAPI:
     def shutdown(self):
         """Shutdown the web API and watcher."""
         self.logger.info("Shutting down WebAPI")
-        self.watcher.handle_exit()
+        # Only shut down watcher we created here
+        if self.watcher_thread is not None:
+            self.watcher.handle_exit()
 
 
 # Global API instance
@@ -575,18 +606,26 @@ async def lifespan(app: FastAPI):
                 config.write(f)
             logger.info("Default config created. Please review config.ini before using the web API.")
 
-        config = AppConfig()
-        state = AppState(logger=logger)
+        # If external components have been attached (from the TUI),
+        # reuse them so that we share a single watcher instance.
+        if _external_components:
+            config = _external_components["config"]
+            state = _external_components["state"]
+            watcher = _external_components["watcher"]
+            logger = _external_components["logger"]
+        else:
+            config = AppConfig()
+            state = AppState(logger=logger)
 
         # Initialize authenticator with config token
         try:
             api_token = config.get("WebServer", "auth_token")
-        except:
+        except Exception:
             api_token = "gengo-token-demo"
         global authenticator
         authenticator = APIAuthenticator(api_token)
 
-        api_instance = WebAPI(config, state, logger)
+        api_instance = WebAPI(config, state, logger, watcher=_external_components["watcher"] if _external_components else None)
         logger.info("WebAPI started successfully")
     except Exception as e:
         logger.exception(f"Failed to start WebAPI: {e}")


### PR DESCRIPTION
This change lets the web API reuse the existing watcher when the TUI starts the web server, instead of spawning a second independent watcher.Key changes:- Add attach_external_components(config, state, watcher, logger) in gengowatcher.web to allow the CLI to pass its live components into the web layer.- Update WebAPI to accept an optional watcher; if provided, it reuses that watcher and *does not* start its own watcher thread.- Only call watcher.handle_exit() on shutdown when WebAPI created the watcher itself.- In main.py, when starting the web server (with --web/--web-only), call attach_external_components(...) before run_web_server so the FastAPI lifespan reuses the existing watcher.Impact:- Running with --web or --web-only no longer creates two watcher instances that both poll RSS/WebSocket and open job pages.- Existing behavior for standalone web server remains unchanged when started directly via gengowatcher.web:run_web_server.