### PR TITLE
feat: gate opening job links

### DIFF
--- a/src/gengowatcher/config.py
+++ b/src/gengowatcher/config.py
@@ -13,6 +13,7 @@ class AppConfig:
             "min_reward": 0.0,
             "enable_notifications": True,
             "enable_sound": True,
+            "open_links_on_new_job": True,
             "use_custom_user_agent": False,
         },
         "WebSocket": {

--- a/src/gengowatcher/watcher.py
+++ b/src/gengowatcher/watcher.py
@@ -337,7 +337,11 @@ class GengoWatcher:
                 self.logger.error(f"Notify Error: {e}")
         if play_sound and self.config.get("Watcher", "enable_sound"):
             threading.Thread(target=self.play_sound, daemon=True).start()
-        if open_link and url:
+        try:
+            allow_open = self.config.get("Watcher", "open_links_on_new_job")
+        except Exception:
+            allow_open = True
+        if open_link and url and allow_open:
             self.open_in_browser(url)
 
 


### PR DESCRIPTION
Adds a config-controlled gate for opening job links in the browser.Changes:- New config key [Watcher] open_links_on_new_job (default True) in AppConfig.DEFAULT_CONFIG.- show_notification now checks open_links_on_new_job before calling open_in_browser(url).Behavior:- Existing users see no change (default is True).- Setting open_links_on_new_job = False prevents job URLs from being auto-opened while still allowing notifications and sounds.