### PR TITLE
test: hardening for LRU and websocket rewards

### DIFF
--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -119,3 +119,32 @@ def test_process_new_job_deduplication(watcher_instance):
     assert mock_state.save_state.call_count == 2
     assert 456 in mock_state.seen_job_ids
     assert mock_state.total_new_entries_found == 2
+
+
+def test_seen_jobs_lru_bounds_set_size(watcher_instance):
+    """Ensure the internal seen-jobs tracking does not grow unbounded."""
+    w = watcher_instance
+    w.show_notification = MagicMock()
+    w.state.total_new_entries_found = 0
+    w.state.seen_job_ids = collections.deque(maxlen=50)
+
+    # Pretend config exposes a small max size for the LRU
+    def fake_get(section, key, **kwargs):
+        if (section, key) == ("Watcher", "seen_jobs_max"):
+            return 10
+        if (section, key) == ("Watcher", "min_reward"):
+            return 0.0
+        if (section, key) == ("AutoAccept", "job_sources"):
+            return "rss,websocket"
+        # Defer to original config for anything else
+        return watcher_instance.config.config.get(section, {}).get(key)
+
+    w.config.get.side_effect = fake_get
+
+    for i in range(50):
+        w._process_new_job(i, f"Job {i}", 1.0, f"http://example.com/{i}", "Test")
+
+    # The external deque remains bounded by its own maxlen
+    assert len(w.state.seen_job_ids) <= 50
+    # The internal session set should not exceed the configured max
+    assert len(w._seen_jobs_session) <= 10

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -139,3 +139,29 @@ async def test_websocket_logic_processes_job(mock_connect, watcher_instance):
         "https://gengo.com/t/jobs/details/9876",
         source="WebSocket",
     )
+
+
+@pytest.mark.asyncio
+@patch("gengowatcher.watcher.websockets.connect")
+async def test_websocket_reward_parsing_is_robust(mock_connect, watcher_instance):
+    """Malformed rewards payloads should not crash the websocket loop."""
+    w = watcher_instance
+    w._process_new_job = MagicMock()
+
+    bad_payloads = [
+        {"type": "available_collection", "collection": {"id": 1, "lc_src": "en", "lc_tgt": "ja", "rewards": {"amount": "9.99"}}},
+        {"type": "available_collection", "collection": {"id": 2, "lc_src": "en", "lc_tgt": "fr", "rewards": "not-a-number"}},
+    ]
+    messages = ["{}"] + [json.dumps(p) for p in bad_payloads]
+    mock_ws_client = MockAsyncWebSocket(messages)
+    mock_connect.return_value = mock_ws_client
+
+    await w._websocket_logic()
+
+    # We still authenticate correctly
+    mock_connect.assert_called_once()
+    mock_ws_client.send.assert_awaited()
+    # And we do not crash when parsing the rewards field
+    # (if the payload shape is unsupported, the job may be skipped,
+    # but the loop must not raise).
+    assert w._process_new_job.call_count >= 0


### PR DESCRIPTION
Adds focused tests for the recent hardening changes.New tests:- tests/test_watcher.py::test_seen_jobs_lru_bounds_set_size  - Exercises _process_new_job with many synthetic jobs and confirms that    the internal _seen_jobs_session does not grow without bound when a    small Watcher.seen_jobs_max is configured.- tests/test_websocket.py::test_websocket_reward_parsing_is_robust  - Feeds WebSocket available_collection messages with unusual rewards    payloads (dict and non-numeric string) and asserts that the loop    authenticates and completes without raising, relying on the new    _safe_parse_reward helper.Notes:- The websocket robustness test is intentionally conservative and only  checks that no crash occurs; it does not depend on a particular  decision about whether the job is accepted or skipped when rewards  are unusable.