### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/scripts/test_high_value_setup.py
+++ b/scripts/test_high_value_setup.py
@@ -7,6 +7,7 @@ import asyncio
 import logging
 import sys
 from pathlib import Path
+from urllib.parse import urlparse
 
 # Add src to path
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
@@ -44,7 +45,13 @@ def test_configuration():
 
         # Check RSS feed URL
         feed_url = config.get("Watcher", "feed_url")
-        if "gengo.com" in feed_url and "YOUR_RSS_KEY" not in feed_url:
+        parsed_feed = urlparse(feed_url or "")
+        host = parsed_feed.hostname
+        if (
+            host
+            and (host == "gengo.com" or host.endswith(".gengo.com"))
+            and "YOUR_RSS_KEY" not in (feed_url or "")
+        ):
             print("✅ RSS feed URL appears to be configured")
         else:
             print("❌ RSS feed URL needs configuration")

--- a/scripts/test_high_value_setup.py
+++ b/scripts/test_high_value_setup.py
@@ -45,12 +45,12 @@ def test_configuration():
 
         # Check RSS feed URL
         feed_url = config.get("Watcher", "feed_url")
-        parsed_feed = urlparse(feed_url or "")
+        parsed_feed = urlparse(feed_url)
         host = parsed_feed.hostname
         if (
             host
             and (host == "gengo.com" or host.endswith(".gengo.com"))
-            and "YOUR_RSS_KEY" not in (feed_url or "")
+            and "YOUR_RSS_KEY" not in feed_url
         ):
             print("✅ RSS feed URL appears to be configured")
         else:


### PR DESCRIPTION
Potential fix for [https://github.com/tdawe1/GengoWatcher/security/code-scanning/2](https://github.com/tdawe1/GengoWatcher/security/code-scanning/2)

In general, instead of checking for a substring like `"gengo.com" in feed_url`, we should parse the URL and inspect its hostname. This ensures that only URLs whose actual host is `gengo.com` or an expected subdomain (e.g., `api.gengo.com`) are considered acceptable, and avoids accidentally accepting URLs where `gengo.com` appears in the path, query, or as part of another domain name.

The best fix here, without changing the observable behavior too much, is to:
1. Import `urlparse` from `urllib.parse`.
2. Replace the substring check with a hostname-based check:
   - Parse `feed_url` with `urlparse`.
   - Extract `hostname`.
   - Consider it “appears to be configured” if the hostname equals `gengo.com` or ends with `.gengo.com`, and the placeholder `"YOUR_RSS_KEY"` is not present.

Concretely:
- In `scripts/test_high_value_setup.py`, add `from urllib.parse import urlparse` alongside the existing imports.
- Replace the `if "gengo.com" in feed_url and "YOUR_RSS_KEY" not in feed_url:` block with logic that uses `urlparse(feed_url).hostname` and checks `host == "gengo.com" or host.endswith(".gengo.com")`, guarding for `host` being `None`.

No other behavior of the script needs to change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
