### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/src/gengowatcher/watcher.py
+++ b/src/gengowatcher/watcher.py
@@ -1287,18 +1287,23 @@ class GengoWatcher:
 
                 prompt = f"  {option} (current: {display_current}){desc_text}: "
 
-                if (
+                is_sensitive = (
                     "password" in option.lower()
                     or "session" in option.lower()
                     or "key" in option.lower()
-                ):
+                )
+
+                if is_sensitive:
                     value = getpass.getpass(prompt)
                 else:
                     value = input(prompt).strip()
 
                 if value:
                     self.set_config_value(section, option, value)
-                    print(f"  ✅ Set {option} = {value}")
+                    if is_sensitive:
+                        print(f"  ✅ Set {option} (value stored securely)")
+                    else:
+                        print(f"  ✅ Set {option} = {value}")
                 else:
                     print(f"  ⚠️  Skipped {option} (keeping current value)")
 

--- a/src/gengowatcher/watcher.py
+++ b/src/gengowatcher/watcher.py
@@ -45,6 +45,8 @@ PLACEHOLDER_CONFIG_VALUES = {
     "REPLACE_WITH_YOUR_USER_KEY",
 }
 
+SENSITIVE_KEYWORDS = {"password", "session", "key"}
+
 
 class GengoWatcher:
     PAUSE_FILE = "gengowatcher.pause"
@@ -1287,11 +1289,7 @@ class GengoWatcher:
 
                 prompt = f"  {option} (current: {display_current}){desc_text}: "
 
-                is_sensitive = (
-                    "password" in option.lower()
-                    or "session" in option.lower()
-                    or "key" in option.lower()
-                )
+                is_sensitive = any(keyword in option.lower() for keyword in SENSITIVE_KEYWORDS)
 
                 if is_sensitive:
                     value = getpass.getpass(prompt)


### PR DESCRIPTION
Potential fix for [https://github.com/tdawe1/GengoWatcher/security/code-scanning/1](https://github.com/tdawe1/GengoWatcher/security/code-scanning/1)

In general, the fix is to avoid printing or logging the actual contents of sensitive values (passwords, tokens, session IDs, API keys). Instead, you can either: (a) print only the option name and say it was set, or (b) print a redacted/masked version (e.g., `******` or a short hash/length) that does not reveal the secret itself.

For this specific code, the simplest, least intrusive way to fix the problem is:

- Detect whether the current `option` is sensitive using the same condition already used to decide between `getpass.getpass` and `input`.
- If the option is sensitive, change the success message to omit `= {value}` (or use a generic placeholder like `= [secret set]`).
- If the option is not sensitive, keep the existing behavior and show the actual value as before.

Concretely:

- In `src/gengowatcher/watcher.py`, around lines 1290–1303, introduce a `is_sensitive` boolean that reuses the existing `"password" in option.lower() or ...` logic.
- Use `is_sensitive` both for choosing `getpass.getpass` vs `input` and for choosing between a redacted confirmation message for sensitive options and the current detailed message for non-sensitive options.
- No new imports are needed.

This preserves functionality (config values are still read and stored identically) while preventing sensitive inputs from being exposed in clear text.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
