### PR TITLE
Potential fix for code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/src/gengowatcher/web.py
+++ b/src/gengowatcher/web.py
@@ -965,7 +965,12 @@ async def health_check():
             "timestamp": time.time(),
         }
     except Exception as e:
-        return {"status": "unhealthy", "detail": str(e), "timestamp": time.time()}
+        logging.exception("Health check failed: %s", e)
+        return {
+            "status": "unhealthy",
+            "detail": "Internal error",
+            "timestamp": time.time(),
+        }
 
 
 @app.get("/web/{path:path}")

--- a/src/gengowatcher/web.py
+++ b/src/gengowatcher/web.py
@@ -965,7 +965,7 @@ async def health_check():
             "timestamp": time.time(),
         }
     except Exception as e:
-        logging.exception("Health check failed: %s", e)
+        api_instance.logger.exception(f"Health check failed: {e}")
         return {
             "status": "unhealthy",
             "detail": "Internal error",


### PR DESCRIPTION
Potential fix for [https://github.com/tdawe1/GengoWatcher/security/code-scanning/4](https://github.com/tdawe1/GengoWatcher/security/code-scanning/4)

To fix the problem, the error information should be logged on the server side and a generic, non-sensitive error message should be returned to the client. This preserves debuggability while preventing attackers from seeing internal details. Specifically, we should remove `str(e)` from the response body and instead log the exception using the existing logging mechanism (`api_instance.logger` or the module-level `logging`).

The best minimal change, consistent with the rest of the file, is to modify the `except` block in `health_check` (lines 967–968). Instead of returning `{"status": "unhealthy", "detail": str(e), "timestamp": time.time()}`, we should first log the exception, then return a response where `detail` is a generic message like `"Internal error"` or `"Health check failed"`, without including `e`. We can reuse `api_instance.logger` if `api_instance` is initialized; otherwise fall back to the module logger, but to keep changes minimal and avoid assumptions, we can simply use the module-level `logging` which is already imported and configured elsewhere.

Concretely:
- In `src/gengowatcher/web.py`, find the `except Exception as e:` block in `health_check`.
- Replace the single `return` with two statements:
  - `logging.exception("Health check failed: %s", e)` to log the full stack trace.
  - `return {"status": "unhealthy", "detail": "Internal error", "timestamp": time.time()}` or similar, omitting `e`.
No new imports or helper methods are required, as `logging` and `time` are already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
