### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/src/gengowatcher/web.py
+++ b/src/gengowatcher/web.py
@@ -538,7 +538,16 @@ class WebAPI:
             else:
                 return {"status": "error", "message": f"Unknown command: {command}"}
         except Exception as e:
-            return {"status": "error", "message": str(e)}
+            # Log full details server-side, but return a generic error message
+            self.logger.exception(
+                f"Unexpected error executing watcher command '%s': %s",
+                command,
+                e,
+            )
+            return {
+                "status": "error",
+                "message": "Internal command execution error",
+            }
 
     async def broadcast_status_update(self):
         """Broadcast status update to all connected WebSocket clients."""


### PR DESCRIPTION
Potential fix for [https://github.com/tdawe1/GengoWatcher/security/code-scanning/3](https://github.com/tdawe1/GengoWatcher/security/code-scanning/3)

In general, the fix is to avoid returning raw exception messages to the client. Instead, log the detailed error (including stack trace) on the server and send a generic, non-sensitive error message to the client, or a controlled, sanitized message where appropriate.

In this codebase, the best fix is to change `GengoWatcherAPI.execute_command` so that its `except Exception` block does not embed `str(e)` in the returned JSON. Instead, it should:

- Log the exception using the existing `self.logger` with `.exception(...)` to capture the stack trace on the server.
- Return a generic error response such as `{"status": "error", "message": "Internal command execution error"}` that contains no implementation details.

The FastAPI route `execute_command` (lines 804–820) already logs and converts unexpected exceptions into a 500 with `"Internal server error"`, and converts known `"status": "error"` results into a 400 with a message. After our change, the only error message that can come from `api_instance.execute_command` in the unexpected-exception case will be the generic one we set, avoiding exposure of stack trace / exception detail to clients while preserving behavior (the client still sees `status: "error"` on command-level failures, just without sensitive internals).

Concretely:

- In `src/gengowatcher/web.py`, around lines 510–541, replace:

```py
        except Exception as e:
            return {"status": "error", "message": str(e)}
```

with something like:

```py
        except Exception as e:
            self.logger.exception(f"Error executing watcher command '{command}': {e}")
            return {
                "status": "error",
                "message": "Internal command execution error",
            }
```

No new imports are needed; `self.logger` is already defined on the API instance elsewhere in this file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
