### PR TITLE
fix(ui): populate all tab panels and refresh only on job detection

### DIFF
--- a/src/gengowatcher/stats.py
+++ b/src/gengowatcher/stats.py
@@ -34,6 +34,7 @@ class AllTimeStats:
     """Aggregate statistics across all sessions."""
 
     total_jobs: int = 0
+    total_jobs_accepted: int = 0
     total_value: float = 0.0
     total_sessions: int = 0
     best_day_value: float = 0.0
@@ -135,6 +136,7 @@ class StatsManager:
             # All-time stats
             self.all_time.total_jobs += 1
             if accepted:
+                self.all_time.total_jobs_accepted += 1
                 self.all_time.total_value += reward
 
             # Source stats

--- a/src/gengowatcher/stats.py
+++ b/src/gengowatcher/stats.py
@@ -42,7 +42,7 @@ class AllTimeStats:
 
     @property
     def avg_job_value(self) -> float:
-        return self.total_value / max(self.total_jobs, 1)
+        return self.total_value / max(self.total_jobs_accepted, 1)
 
 
 @dataclass

--- a/src/gengowatcher/ui_textual.py
+++ b/src/gengowatcher/ui_textual.py
@@ -780,14 +780,18 @@ class JobsPanel(Static):
                 source = job.get("source", "unknown")
                 status = "✓" if job.get("accepted", False) else "○"
                 timestamp = job.get("timestamp", job.get("found_at", ""))
-                if timestamp:
+                if isinstance(timestamp, (int, float)):
+                    timestamp = datetime.datetime.fromtimestamp(timestamp).strftime('%H:%M:%S')
+                elif isinstance(timestamp, str):
                     # Extract just the time portion if it's a full timestamp
-                    if "T" in str(timestamp):
-                        timestamp = str(timestamp).split("T")[1][:8]
-                    elif " " in str(timestamp):
-                        timestamp = str(timestamp).split(" ")[1][:8]
+                    if "T" in timestamp:
+                        timestamp = timestamp.split("T")[1][:8]
+                    elif " " in timestamp:
+                        timestamp = timestamp.split(" ")[1][:8]
                     else:
-                        timestamp = str(timestamp)[:8]
+                        timestamp = timestamp[:8]
+                else:
+                    timestamp = ""
                 dt.add_row(job_id, pair, words, reward, source, status, timestamp)
         except NoMatches:
             pass  # Widget not mounted yet

--- a/src/gengowatcher/ui_textual.py
+++ b/src/gengowatcher/ui_textual.py
@@ -969,22 +969,21 @@ class GengoWatcherApp(App):
 
     def _refresh_all_panels(self):
         """Refresh all data panels when a new job is detected."""
-        try:
-            # Dashboard widgets
-            self.query_one(MetricsRow).refresh_metrics()
-            self.query_one(JobsPreview).refresh_jobs()
-            self.query_one(JobsHourChart).refresh_chart()
-            self.query_one(SessionStats).refresh_stats()
-        except NoMatches:
-            pass
-
-        try:
-            # Tab panels
-            self.query_one(JobsPanel).refresh_jobs()
-            self.query_one(ChartsPanel).refresh_charts()
-            self.query_one(StatsPanel).refresh_stats()
-        except NoMatches:
-            pass
+        widgets_to_refresh = [
+            (MetricsRow, "refresh_metrics"),
+            (JobsPreview, "refresh_jobs"),
+            (JobsHourChart, "refresh_chart"),
+            (SessionStats, "refresh_stats"),
+            (JobsPanel, "refresh_jobs"),
+            (ChartsPanel, "refresh_charts"),
+            (StatsPanel, "refresh_stats"),
+        ]
+        for widget_class, method_name in widgets_to_refresh:
+            try:
+                widget = self.query_one(widget_class)
+                getattr(widget, method_name)()
+            except NoMatches:
+                pass
 
     def _setup_logging(self):
         handler = TextualLogHandler(self)

--- a/src/gengowatcher/ui_textual.py
+++ b/src/gengowatcher/ui_textual.py
@@ -200,6 +200,28 @@ def _render_chart(values: list[float], width: int = 20, height: int = 5) -> str:
     return "\n".join(lines)
 
 
+def _parse_job_title_fallback(title: Any) -> tuple[str, str]:
+    """Fallback parser for language pair and word count from job title."""
+
+    default_pair = "??→??"
+    default_words = "0"
+    if not title:
+        return default_pair, default_words
+
+    text = str(title)
+    pair_match = re.search(
+        r"\b([A-Z]{2})\s*(?:→|->|-|>)\s*([A-Z]{2})\b", text, re.IGNORECASE
+    )
+    if pair_match:
+        pair = f"{pair_match.group(1).upper()}→{pair_match.group(2).upper()}"
+    else:
+        pair = default_pair
+
+    words_match = re.search(r"\b(\d{1,6})\s*words?\b", text, re.IGNORECASE)
+    words = words_match.group(1) if words_match else default_words
+    return pair, words
+
+
 # =============================================================================
 # Widgets
 # =============================================================================
@@ -676,8 +698,16 @@ class JobsPreview(DashboardQuadrant):
             jobs = self.state.get_recent_jobs(limit=10)
             for job in jobs:
                 job_id = str(job.get("id", "N/A"))[:8]
-                pair = job.get("lang_pair", "??→??")
-                words = str(job.get("word_count", job.get("words", 0)))
+                fallback_pair, fallback_words = _parse_job_title_fallback(
+                    job.get("title", "")
+                )
+                pair = job.get("lang_pair") or fallback_pair
+                word_count = job.get("word_count")
+                if word_count is None:
+                    word_count = job.get("words")
+                if word_count is None:
+                    word_count = fallback_words
+                words = str(word_count)
                 reward = f"${job.get('reward', 0):.2f}"
                 dt.add_row(job_id, pair, words, reward)
         except NoMatches:
@@ -919,7 +949,9 @@ class SourcesBreakdown(DashboardQuadrant):
         self.state = state
 
     def compose(self) -> ComposeResult:
-        yield Static("WS: 0%\nEmail: 0%\nWebsite: 0%\nRSS: 0%\nUnknown: 0%", id="sources-content")
+        yield Static(
+            "WS: 0%\nEmail: 0%\nWebsite: 0%\nRSS: 0%\nUnknown: 0%", id="sources-content"
+        )
 
     def refresh_sources(self):
         """Refresh sources breakdown with job source statistics."""
@@ -1040,8 +1072,16 @@ class JobsPanel(Static):
             jobs = self.state.get_recent_jobs(limit=100)
             for job in jobs:
                 job_id = str(job.get("id", "N/A"))[:12]
-                pair = job.get("lang_pair", "??→??")
-                words = str(job.get("word_count", job.get("words", 0)))
+                fallback_pair, fallback_words = _parse_job_title_fallback(
+                    job.get("title", "")
+                )
+                pair = job.get("lang_pair") or fallback_pair
+                word_count = job.get("word_count")
+                if word_count is None:
+                    word_count = job.get("words")
+                if word_count is None:
+                    word_count = fallback_words
+                words = str(word_count)
                 reward = f"${job.get('reward', 0):.2f}"
                 source = job.get("source", "unknown")
                 status = "✓" if job.get("accepted", False) else "○"

--- a/src/gengowatcher/ui_textual.py
+++ b/src/gengowatcher/ui_textual.py
@@ -758,7 +758,7 @@ class JobsPanel(Static):
             )
             dt.cursor_type = "row"
         except NoMatches:
-            pass
+            pass  # Widget not mounted yet
         self.refresh_jobs()
 
     def compose(self) -> ComposeResult:

--- a/src/gengowatcher/ui_textual.py
+++ b/src/gengowatcher/ui_textual.py
@@ -743,7 +743,7 @@ class SourcesBreakdown(DashboardQuadrant):
         self.state = state
 
     def compose(self) -> ComposeResult:
-        yield Static("WS: 0%\nEmail: 0%\nWeb: 0%\nRSS: 0%", id="sources-content")
+        yield Static("WS: 0%\nEmail: 0%\nWebsite: 0%\nRSS: 0%", id="sources-content")
 
     def refresh_sources(self):
         """Refresh sources breakdown with job source statistics."""
@@ -754,18 +754,24 @@ class SourcesBreakdown(DashboardQuadrant):
             total = len(jobs) if jobs else 1  # Avoid division by zero
 
             # Count jobs by source
-            ws_count = sum(1 for j in jobs if j.get("source") == "websocket")
-            email_count = sum(1 for j in jobs if j.get("source") == "email")
-            web_count = sum(1 for j in jobs if j.get("source") == "web")
-            rss_count = sum(1 for j in jobs if j.get("source") == "rss")
+            counts = {"websocket": 0, "email": 0, "website": 0, "rss": 0}
+            for job in jobs:
+                bucket = _normalize_source(job.get("source"))
+                if bucket in counts:
+                    counts[bucket] += 1
 
             # Calculate percentages
-            ws_pct = (ws_count / total) * 100 if total > 0 else 0
-            email_pct = (email_count / total) * 100 if total > 0 else 0
-            web_pct = (web_count / total) * 100 if total > 0 else 0
-            rss_pct = (rss_count / total) * 100 if total > 0 else 0
+            ws_pct = (counts["websocket"] / total) * 100 if total > 0 else 0
+            email_pct = (counts["email"] / total) * 100 if total > 0 else 0
+            website_pct = (counts["website"] / total) * 100 if total > 0 else 0
+            rss_pct = (counts["rss"] / total) * 100 if total > 0 else 0
 
-            content = f"WS: {ws_pct:.0f}%\nEmail: {email_pct:.0f}%\nWeb: {web_pct:.0f}%\nRSS: {rss_pct:.0f}%"
+            content = (
+                f"WS: {ws_pct:.0f}%\n"
+                f"Email: {email_pct:.0f}%\n"
+                f"Website: {website_pct:.0f}%\n"
+                f"RSS: {rss_pct:.0f}%"
+            )
             self.query_one("#sources-content", Static).update(content)
         except NoMatches:
             pass  # Widget not mounted yet
@@ -1223,27 +1229,22 @@ class TextualLogHandler(logging.Handler):
         except Exception:
             pass  # Logging failures should not crash the app
 
-    def write_log(self, msg: str, level: int = logging.INFO):
-        colored_text = self._colorize_message(msg, level)
-        # Write to dashboard activity log
+    def _write_to_log(self, widget_id: str, colored_text: Text) -> None:
         try:
-            log = self.app.query_one("#activity-log", RichLog)
+            log = self.app.query_one(widget_id, RichLog)
             log.write(colored_text)
         except NoMatches:
             pass  # Widget not mounted yet
+
+    def write_log(self, msg: str, level: int = logging.INFO):
+        colored_text = self._colorize_message(msg, level)
+        # Write to dashboard activity log
+        self._write_to_log("#activity-log", colored_text)
         # Also write to full activity log tab
-        try:
-            log_full = self.app.query_one("#activity-log-full", RichLog)
-            log_full.write(colored_text)
-        except NoMatches:
-            pass  # Widget not mounted yet
+        self._write_to_log("#activity-log-full", colored_text)
         # Also write to output log for system output
         if level >= logging.WARNING:
-            try:
-                output_log = self.app.query_one("#output-log", RichLog)
-                output_log.write(colored_text)
-            except NoMatches:
-                pass  # Widget not mounted yet
+            self._write_to_log("#output-log", colored_text)
 
     def _colorize_message(self, msg: str, level: int) -> Text:
         """Apply Rich markup coloring based on content patterns."""

--- a/src/gengowatcher/ui_textual.py
+++ b/src/gengowatcher/ui_textual.py
@@ -835,7 +835,11 @@ class ChartsPanel(Static):
             value_text = self._render_value_trend()
             self.query_one("#chart-value", Static).update(value_text)
         except NoMatches:
-            pass
+            # Chart widgets may not be present yet (e.g., during initial layout);
+            # safely ignore missing targets when refreshing charts.
+            logging.getLogger(__name__).debug(
+                "ChartsPanel.refresh_charts: chart widgets not found; skipping update"
+            )
 
     def _render_hourly_chart(self) -> Text:
         """Render hourly job distribution chart."""

--- a/src/gengowatcher/ui_textual.py
+++ b/src/gengowatcher/ui_textual.py
@@ -1010,6 +1010,9 @@ class GengoWatcherApp(App):
                 widget = self.query_one(widget_class)
                 getattr(widget, method_name)()
             except NoMatches:
+                # It is expected that some widgets may not be present in the UI
+                # at certain times (e.g., different tabs or layouts). In those
+                # cases, we simply skip refreshing that widget.
                 logging.getLogger(__name__).debug(
                     "Widget %s not found while refreshing panels.", widget_class.__name__
                 )

--- a/src/gengowatcher/ui_textual.py
+++ b/src/gengowatcher/ui_textual.py
@@ -865,20 +865,19 @@ class ChartsPanel(Static):
         jobs = self.state.get_recent_jobs(limit=1000)
         total = len(jobs) if jobs else 1
 
-        sources = {"websocket": 0, "email": 0, "web": 0, "rss": 0, "unknown": 0}
+        sources = {"WebSocket": 0, "email": 0, "website": 0, "RSS": 0, "unknown": 0}
         for job in jobs:
             src = job.get("source", "unknown")
-            if src in sources:
-                sources[src] += 1
-            else:
-                sources["unknown"] += 1
+            if src not in sources:
+                src = "unknown"
+            sources[src] += 1
 
         max_count = max(sources.values()) if sources else 1
         colors = {
-            "websocket": "#957FB8",
+            "WebSocket": "#957FB8",
             "email": "#FFA066",
-            "web": "#7E9CD8",
-            "rss": "#7AA89F",
+            "website": "#7E9CD8",
+            "RSS": "#7AA89F",
             "unknown": "#727169",
         }
 

--- a/src/gengowatcher/ui_textual.py
+++ b/src/gengowatcher/ui_textual.py
@@ -1234,7 +1234,7 @@ class GengoWatcherApp(App):
         dashboard_widgets = [
             (MetricsRow, "refresh_metrics"),
             (JobsPreview, "refresh_jobs"),
-            (JobsHourChart, "refresh_chart"),
+            (HourlyActivity, "refresh_hourly"),
             (SessionStats, "refresh_stats"),
         ]
 

--- a/src/gengowatcher/ui_textual.py
+++ b/src/gengowatcher/ui_textual.py
@@ -910,7 +910,7 @@ class ChartsPanel(Static):
         # Calculate cumulative value over last N jobs
         cumulative = 0
         values = []
-        for job in reversed(jobs[-20:]):  # Last 20 jobs
+        for job in reversed(jobs[:20]):  # Last 20 jobs
             cumulative += job.get("reward", 0)
             values.append(cumulative)
 

--- a/src/gengowatcher/ui_textual.py
+++ b/src/gengowatcher/ui_textual.py
@@ -743,7 +743,7 @@ class SourcesBreakdown(DashboardQuadrant):
         self.state = state
 
     def compose(self) -> ComposeResult:
-        yield Static("WS: 0%\nEmail: 0%\nWebsite: 0%\nRSS: 0%", id="sources-content")
+        yield Static("WS: 0%\nEmail: 0%\nWebsite: 0%\nRSS: 0%\nUnknown: 0%", id="sources-content")
 
     def refresh_sources(self):
         """Refresh sources breakdown with job source statistics."""
@@ -754,23 +754,27 @@ class SourcesBreakdown(DashboardQuadrant):
             total = len(jobs) if jobs else 1  # Avoid division by zero
 
             # Count jobs by source
-            counts = {"websocket": 0, "email": 0, "website": 0, "rss": 0}
+            counts = {"websocket": 0, "email": 0, "website": 0, "rss": 0, "unknown": 0}
             for job in jobs:
                 bucket = _normalize_source(job.get("source"))
                 if bucket in counts:
                     counts[bucket] += 1
+                else:
+                    counts["unknown"] += 1
 
             # Calculate percentages
             ws_pct = (counts["websocket"] / total) * 100 if total > 0 else 0
             email_pct = (counts["email"] / total) * 100 if total > 0 else 0
             website_pct = (counts["website"] / total) * 100 if total > 0 else 0
             rss_pct = (counts["rss"] / total) * 100 if total > 0 else 0
+            unknown_pct = (counts["unknown"] / total) * 100 if total > 0 else 0
 
             content = (
                 f"WS: {ws_pct:.0f}%\n"
                 f"Email: {email_pct:.0f}%\n"
                 f"Website: {website_pct:.0f}%\n"
-                f"RSS: {rss_pct:.0f}%"
+                f"RSS: {rss_pct:.0f}%\n"
+                f"Unknown: {unknown_pct:.0f}%"
             )
             self.query_one("#sources-content", Static).update(content)
         except NoMatches:

--- a/src/gengowatcher/ui_textual.py
+++ b/src/gengowatcher/ui_textual.py
@@ -179,7 +179,7 @@ class TitleBar(Static):
             self.query_one("#clock", Static).update(now.strftime("%H:%M:%S"))
         except NoMatches:
             logging.getLogger(__name__).debug(
-                "SourcesBreakdown.refresh_sources: widget not mounted yet"
+                "TitleBar.update_clock: widget not mounted yet"
             )
 
         # Session timer
@@ -224,7 +224,7 @@ class MetricCard(Static):
             self.query_one(f"#val-{self.label.lower()}", Static).update(value)
         except NoMatches:
             logging.getLogger(__name__).debug(
-                "StatsPanel.refresh_stats: stats widgets not mounted yet"
+                "MetricCard.update_value: metric value widget not mounted yet"
             )
 
 
@@ -757,10 +757,7 @@ class SourcesBreakdown(DashboardQuadrant):
             counts = {"websocket": 0, "email": 0, "website": 0, "rss": 0, "unknown": 0}
             for job in jobs:
                 bucket = _normalize_source(job.get("source"))
-                if bucket in counts:
-                    counts[bucket] += 1
-                else:
-                    counts["unknown"] += 1
+                counts[bucket] += 1
 
             # Calculate percentages
             ws_pct = (counts["websocket"] / total) * 100 if total > 0 else 0

--- a/src/gengowatcher/ui_textual.py
+++ b/src/gengowatcher/ui_textual.py
@@ -825,7 +825,7 @@ class StatsPanel(Static):
             alltime = self.stats.all_time
             alltime_text = (
                 f"Total Jobs: {alltime.total_jobs}\n"
-                f"Total Accepted: {alltime.total_sessions}\n"
+                f"Total Accepted: {alltime.total_jobs_accepted}\n"
                 f"Total Value: ${alltime.total_value:.2f}"
             )
             self.query_one("#stats-alltime-content", Static).update(alltime_text)

--- a/src/gengowatcher/ui_textual.py
+++ b/src/gengowatcher/ui_textual.py
@@ -967,22 +967,46 @@ class GengoWatcherApp(App):
         self.call_from_thread(self._refresh_all_panels)
 
     def _refresh_all_panels(self):
-        """Refresh all data panels when a new job is detected."""
-        widgets_to_refresh = [
+        """Refresh relevant data panels when a new job is detected."""
+        # Determine which tab is currently active so we only refresh visible panels.
+        try:
+            tabbed_content = self.query_one(TabbedContent)
+            active_tab_id = tabbed_content.active
+        except NoMatches:
+            # If TabbedContent can't be found, fall back to refreshing dashboard widgets.
+            active_tab_id = None
+
+        # Widgets that live on the dashboard tab.
+        dashboard_widgets = [
             (MetricsRow, "refresh_metrics"),
             (JobsPreview, "refresh_jobs"),
             (JobsHourChart, "refresh_chart"),
             (SessionStats, "refresh_stats"),
-            (JobsPanel, "refresh_jobs"),
-            (ChartsPanel, "refresh_charts"),
-            (StatsPanel, "refresh_stats"),
         ]
+
+        widgets_to_refresh = []
+
+        # When no active tab is known, or when the dashboard is active,
+        # refresh the dashboard widgets to keep the main view up to date.
+        if active_tab_id in (None, "dashboard"):
+            widgets_to_refresh.extend(dashboard_widgets)
+
+        # Only refresh widgets belonging to the currently active non-dashboard tab.
+        if active_tab_id == "jobs":
+            widgets_to_refresh.append((JobsPanel, "refresh_jobs"))
+        elif active_tab_id == "charts":
+            widgets_to_refresh.append((ChartsPanel, "refresh_charts"))
+        elif active_tab_id == "stats":
+            widgets_to_refresh.append((StatsPanel, "refresh_stats"))
+
         for widget_class, method_name in widgets_to_refresh:
             try:
                 widget = self.query_one(widget_class)
                 getattr(widget, method_name)()
             except NoMatches:
-                pass
+                logging.getLogger(__name__).debug(
+                    "Widget %s not found while refreshing panels.", widget_class.__name__
+                )
 
     def _setup_logging(self):
         handler = TextualLogHandler(self)

--- a/src/gengowatcher/ui_textual.py
+++ b/src/gengowatcher/ui_textual.py
@@ -9,6 +9,7 @@ import logging
 import re
 import time
 from collections import deque
+from typing import Any
 
 from textual.app import App, ComposeResult
 from textual.binding import Binding
@@ -57,6 +58,80 @@ class Icons:
     POLLING = "↻"
 
 
+def _format_timestamp(timestamp: Any) -> str:
+    """Normalize a timestamp value to "HH:MM:SS" for display."""
+
+    if timestamp is None:
+        return ""
+
+    if isinstance(timestamp, (int, float)) and not isinstance(timestamp, bool):
+        try:
+            dt = datetime.datetime.fromtimestamp(timestamp)
+        except (OSError, OverflowError, ValueError):
+            return ""
+        return dt.strftime("%H:%M:%S")
+
+    if isinstance(timestamp, str):
+        cleaned = timestamp.strip()
+        if not cleaned:
+            return ""
+
+        iso_candidate = cleaned
+        if iso_candidate.endswith("Z"):
+            iso_candidate = iso_candidate[:-1] + "+00:00"
+        try:
+            dt = datetime.datetime.fromisoformat(iso_candidate)
+            return dt.strftime("%H:%M:%S")
+        except ValueError:
+            pass
+
+        for sep in ("T", " "):
+            if sep in cleaned:
+                _, _, tail = cleaned.partition(sep)
+                match = re.match(r"(\d{2}:\d{2}:\d{2})", tail)
+                if match:
+                    return match.group(1)
+
+        match = re.match(r"(\d{2}:\d{2}:\d{2})", cleaned)
+        if match:
+            return match.group(1)
+        return ""
+
+    return ""
+
+
+SOURCE_BUCKET_CONFIG = {
+    "websocket": {"label": "WebSocket", "color": "#957FB8"},
+    "email": {"label": "Email", "color": "#FFA066"},
+    "website": {"label": "Website", "color": "#7E9CD8"},
+    "rss": {"label": "RSS", "color": "#7AA89F"},
+    "unknown": {"label": "Unknown", "color": "#727169"},
+}
+
+
+def _normalize_source(source: Any) -> str:
+    """Map incoming source strings into the normalized buckets."""
+
+    if source is None:
+        return "unknown"
+
+    normalized = str(source).strip().lower()
+    if not normalized:
+        return "unknown"
+
+    if "websocket" in normalized or normalized in ("ws", "socket"):
+        return "websocket"
+    if any(token in normalized for token in ("email", "imap", "mail")):
+        return "email"
+    if any(token in normalized for token in ("rss", "feed")):
+        return "rss"
+    if any(
+        token in normalized for token in ("web", "http", "browser", "scrape", "website")
+    ):
+        return "website"
+    return "unknown"
+
+
 # =============================================================================
 # Widgets
 # =============================================================================
@@ -103,7 +178,9 @@ class TitleBar(Static):
         try:
             self.query_one("#clock", Static).update(now.strftime("%H:%M:%S"))
         except NoMatches:
-            pass  # Widget not mounted yet
+            logging.getLogger(__name__).debug(
+                "SourcesBreakdown.refresh_sources: widget not mounted yet"
+            )
 
         # Session timer
         app = self.app
@@ -146,7 +223,9 @@ class MetricCard(Static):
         try:
             self.query_one(f"#val-{self.label.lower()}", Static).update(value)
         except NoMatches:
-            pass  # Widget not mounted yet
+            logging.getLogger(__name__).debug(
+                "StatsPanel.refresh_stats: stats widgets not mounted yet"
+            )
 
 
 class MetricsRow(Horizontal):
@@ -538,7 +617,9 @@ class JobsHourChart(DashboardQuadrant):
             chart_text = self._render_chart()
             content.update(chart_text)
         except NoMatches:
-            pass  # Widget not mounted yet
+            logging.getLogger(__name__).debug(
+                "JobsHourChart.refresh_chart: chart content not mounted yet"
+            )
 
     def _render_chart(self) -> Text:
         """Render ASCII bar chart for hourly job distribution."""
@@ -758,7 +839,9 @@ class JobsPanel(Static):
             )
             dt.cursor_type = "row"
         except NoMatches:
-            pass  # Widget not mounted yet
+            logging.getLogger(__name__).debug(
+                "JobsPanel.on_mount: full jobs table not yet mounted"
+            )
         self.refresh_jobs()
 
     def compose(self) -> ComposeResult:
@@ -779,24 +862,13 @@ class JobsPanel(Static):
                 reward = f"${job.get('reward', 0):.2f}"
                 source = job.get("source", "unknown")
                 status = "✓" if job.get("accepted", False) else "○"
-                timestamp = job.get("timestamp", job.get("found_at", ""))
-                if isinstance(timestamp, (int, float)):
-                    timestamp = datetime.datetime.fromtimestamp(timestamp).strftime('%H:%M:%S')
-                elif isinstance(timestamp, str):
-                    # Extract just the time portion if it's a full timestamp
-                    if "T" in timestamp:
-                        timestamp = timestamp.split("T")[1][:8]
-                    elif " " in timestamp:
-                        timestamp = timestamp.split(" ")[1][:8]
-                    else:
-                        # Fallback: timestamp is assumed to already be a time-like string
-                        # (e.g. "12:34:56"); truncate to 8 chars to enforce "HH:MM:SS".
-                        timestamp = timestamp[:8]
-                else:
-                    timestamp = ""
+                timestamp_raw = job.get("timestamp", job.get("found_at"))
+                timestamp = _format_timestamp(timestamp_raw)
                 dt.add_row(job_id, pair, words, reward, source, status, timestamp)
         except NoMatches:
-            pass  # Widget not mounted yet
+            logging.getLogger(__name__).debug(
+                "JobsPanel.refresh_jobs: full jobs table missing during refresh"
+            )
 
 
 class ChartsPanel(Static):
@@ -869,34 +941,26 @@ class ChartsPanel(Static):
             return text
 
         jobs = self.state.get_recent_jobs(limit=1000)
-        total = len(jobs) if jobs else 1
-
-        sources = {"WebSocket": 0, "email": 0, "website": 0, "RSS": 0, "unknown": 0}
+        sources = {key: 0 for key in SOURCE_BUCKET_CONFIG}
         for job in jobs:
-            src = job.get("source", "unknown")
-            if src not in sources:
-                src = "unknown"
-            sources[src] += 1
+            bucket = _normalize_source(job.get("source"))
+            sources[bucket] += 1
 
+        total = sum(sources.values()) or 1
         max_count = max(sources.values()) if sources else 1
-        colors = {
-            "WebSocket": "#957FB8",
-            "email": "#FFA066",
-            "website": "#7E9CD8",
-            "RSS": "#7AA89F",
-            "unknown": "#727169",
-        }
+        if max_count == 0:
+            max_count = 1
 
-        for source, count in sources.items():
+        for bucket_key, bucket in SOURCE_BUCKET_CONFIG.items():
+            count = sources.get(bucket_key, 0)
             pct = (count / total) * 100 if total > 0 else 0
             bar_width = int((count / max_count) * 15) if max_count > 0 else 0
             bar = "█" * bar_width
             bar_padded = bar.ljust(15, "░")
-            text.append(f"{source:10s} ", style="#737c73")
-            text.append(
-                bar_padded,
-                style=colors.get(source, "#727169") if count > 0 else "#393836",
-            )
+            label = bucket["label"]
+            color = bucket["color"] if count > 0 else "#393836"
+            text.append(f"{label:10s} ", style="#737c73")
+            text.append(bar_padded, style=color)
             text.append(f" {count:4d} ({pct:5.1f}%)\n", style="#737c73")
         return text
 
@@ -912,10 +976,11 @@ class ChartsPanel(Static):
             text.append("No jobs recorded yet")
             return text
 
-        # Calculate cumulative value over last N jobs
+        # Calculate cumulative value over the most recent 20 jobs
         cumulative = 0
         values = []
-        for job in reversed(jobs[:20]):  # Last 20 jobs
+        recent_jobs = jobs[:20]
+        for job in reversed(recent_jobs):
             cumulative += job.get("reward", 0)
             values.append(cumulative)
 
@@ -967,7 +1032,7 @@ class GengoWatcherApp(App):
         # Register callback for when new jobs are detected
         self.watcher.on_job_added_callback = self._on_job_added_from_thread
 
-    def _on_job_added_from_thread(self, job_data: dict):
+    def _on_job_added_from_thread(self, _job_data: dict):
         """Called from watcher thread when a new job is added."""
         # Use call_from_thread to safely update UI from watcher thread
         self.call_from_thread(self._refresh_all_panels)
@@ -1006,16 +1071,27 @@ class GengoWatcherApp(App):
             widgets_to_refresh.append((StatsPanel, "refresh_stats"))
 
         for widget_class, method_name in widgets_to_refresh:
-            try:
-                widget = self.query_one(widget_class)
-                getattr(widget, method_name)()
-            except NoMatches:
-                # It is expected that some widgets may not be present in the UI
-                # at certain times (e.g., different tabs or layouts). In those
-                # cases, we simply skip refreshing that widget.
-                logging.getLogger(__name__).debug(
-                    "Widget %s not found while refreshing panels.", widget_class.__name__
-                )
+            self._refresh_widget(widget_class, method_name)
+
+    def _refresh_widget(self, widget_class, method_name: str) -> None:
+        """Attempt to refresh a specific widget and log when it's missing."""
+        try:
+            widget = self.query_one(widget_class)
+        except NoMatches:
+            logging.getLogger(__name__).debug(
+                "Widget %s missing while refreshing %s",
+                widget_class.__name__,
+                method_name,
+            )
+            return
+
+        method = getattr(widget, method_name, None)
+        if callable(method):
+            method()
+        else:
+            logging.getLogger(__name__).warning(
+                "Widget %s has no method %s", widget_class.__name__, method_name
+            )
 
     def _setup_logging(self):
         handler = TextualLogHandler(self)

--- a/src/gengowatcher/ui_textual.py
+++ b/src/gengowatcher/ui_textual.py
@@ -530,8 +530,6 @@ class JobsHourChart(DashboardQuadrant):
 
     def on_mount(self):
         self.refresh_chart()
-        # Refresh chart every 30 seconds
-        self.set_interval(30.0, self.refresh_chart)
 
     def refresh_chart(self):
         """Refresh the chart with current hourly data."""
@@ -699,6 +697,10 @@ class StatsPanel(Static):
         super().__init__(**kwargs)
         self.stats = stats
 
+    def on_mount(self):
+        """Initialize stats display."""
+        self.refresh_stats()
+
     def compose(self) -> ComposeResult:
         with Vertical():
             # Session Stats Section
@@ -740,6 +742,189 @@ class StatsPanel(Static):
             pass  # Widget not mounted yet
 
 
+class JobsPanel(Static):
+    """Full jobs panel for the Jobs tab with detailed job listing."""
+
+    def __init__(self, state: "AppState", **kwargs):
+        super().__init__(**kwargs)
+        self.state = state
+
+    def on_mount(self):
+        """Initialize the jobs table with columns."""
+        try:
+            dt = self.query_one("#jobs-table-full", DataTable)
+            dt.add_columns(
+                "ID", "Lang Pair", "Words", "Reward", "Source", "Status", "Time"
+            )
+            dt.cursor_type = "row"
+        except NoMatches:
+            pass
+        self.refresh_jobs()
+
+    def compose(self) -> ComposeResult:
+        yield DataTable(id="jobs-table-full")
+
+    def refresh_jobs(self):
+        """Refresh the full jobs table with all recent jobs."""
+        if not self.state:
+            return
+        try:
+            dt = self.query_one("#jobs-table-full", DataTable)
+            dt.clear()
+            jobs = self.state.get_recent_jobs(limit=100)
+            for job in jobs:
+                job_id = str(job.get("id", "N/A"))[:12]
+                pair = job.get("lang_pair", "??→??")
+                words = str(job.get("word_count", job.get("words", 0)))
+                reward = f"${job.get('reward', 0):.2f}"
+                source = job.get("source", "unknown")
+                status = "✓" if job.get("accepted", False) else "○"
+                timestamp = job.get("timestamp", job.get("found_at", ""))
+                if timestamp:
+                    # Extract just the time portion if it's a full timestamp
+                    if "T" in str(timestamp):
+                        timestamp = str(timestamp).split("T")[1][:8]
+                    elif " " in str(timestamp):
+                        timestamp = str(timestamp).split(" ")[1][:8]
+                    else:
+                        timestamp = str(timestamp)[:8]
+                dt.add_row(job_id, pair, words, reward, source, status, timestamp)
+        except NoMatches:
+            pass  # Widget not mounted yet
+
+
+class ChartsPanel(Static):
+    """Charts panel showing various job statistics visualizations."""
+
+    def __init__(self, stats: "StatsManager", state: "AppState", **kwargs):
+        super().__init__(**kwargs)
+        self.stats = stats
+        self.state = state
+
+    def on_mount(self):
+        """Initialize charts display."""
+        self.refresh_charts()
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Static("── Jobs by Hour ──", classes="chart-section-header")
+            yield Static(id="chart-hourly", classes="chart-ascii")
+            yield Static("── Jobs by Source ──", classes="chart-section-header")
+            yield Static(id="chart-sources", classes="chart-ascii")
+            yield Static("── Value Trend ──", classes="chart-section-header")
+            yield Static(id="chart-value", classes="chart-ascii")
+
+    def refresh_charts(self):
+        """Refresh all charts with current data."""
+        try:
+            # Hourly chart
+            hourly_text = self._render_hourly_chart()
+            self.query_one("#chart-hourly", Static).update(hourly_text)
+
+            # Sources chart
+            sources_text = self._render_sources_chart()
+            self.query_one("#chart-sources", Static).update(sources_text)
+
+            # Value trend
+            value_text = self._render_value_trend()
+            self.query_one("#chart-value", Static).update(value_text)
+        except NoMatches:
+            pass
+
+    def _render_hourly_chart(self) -> Text:
+        """Render hourly job distribution chart."""
+        text = Text()
+        if self.stats:
+            hourly = dict(self.stats.hourly_counts)
+            max_count = max(hourly.values()) if hourly else 1
+        else:
+            hourly = {}
+            max_count = 1
+
+        for hour in range(24):
+            count = hourly.get(hour, 0)
+            bar_width = int((count / max_count) * 20) if max_count > 0 else 0
+            bar = "█" * bar_width
+            bar_padded = bar.ljust(20, "░")
+            text.append(f"{hour:02d}:00 ", style="#737c73")
+            text.append(bar_padded, style="#8a9a7b" if count > 0 else "#393836")
+            text.append(f" {count:3d}\n", style="#737c73")
+        return text
+
+    def _render_sources_chart(self) -> Text:
+        """Render job sources distribution chart."""
+        text = Text()
+        if not self.state:
+            text.append("No data available")
+            return text
+
+        jobs = self.state.get_recent_jobs(limit=1000)
+        total = len(jobs) if jobs else 1
+
+        sources = {"websocket": 0, "email": 0, "web": 0, "rss": 0, "unknown": 0}
+        for job in jobs:
+            src = job.get("source", "unknown")
+            if src in sources:
+                sources[src] += 1
+            else:
+                sources["unknown"] += 1
+
+        max_count = max(sources.values()) if sources else 1
+        colors = {
+            "websocket": "#957FB8",
+            "email": "#FFA066",
+            "web": "#7E9CD8",
+            "rss": "#7AA89F",
+            "unknown": "#727169",
+        }
+
+        for source, count in sources.items():
+            pct = (count / total) * 100 if total > 0 else 0
+            bar_width = int((count / max_count) * 15) if max_count > 0 else 0
+            bar = "█" * bar_width
+            bar_padded = bar.ljust(15, "░")
+            text.append(f"{source:10s} ", style="#737c73")
+            text.append(
+                bar_padded,
+                style=colors.get(source, "#727169") if count > 0 else "#393836",
+            )
+            text.append(f" {count:4d} ({pct:5.1f}%)\n", style="#737c73")
+        return text
+
+    def _render_value_trend(self) -> Text:
+        """Render value accumulation trend."""
+        text = Text()
+        if not self.state:
+            text.append("No data available")
+            return text
+
+        jobs = self.state.get_recent_jobs(limit=50)
+        if not jobs:
+            text.append("No jobs recorded yet")
+            return text
+
+        # Calculate cumulative value over last N jobs
+        cumulative = 0
+        values = []
+        for job in reversed(jobs[-20:]):  # Last 20 jobs
+            cumulative += job.get("reward", 0)
+            values.append(cumulative)
+
+        if not values:
+            text.append("No value data")
+            return text
+
+        max_val = max(values) if values else 1
+        for i, val in enumerate(values):
+            bar_width = int((val / max_val) * 25) if max_val > 0 else 0
+            bar = "▓" * bar_width
+            bar_padded = bar.ljust(25, "░")
+            text.append(f"{i + 1:2d} ", style="#737c73")
+            text.append(bar_padded, style="#E6C384")
+            text.append(f" ${val:.2f}\n", style="#E6C384")
+        return text
+
+
 # =============================================================================
 # Main App
 # =============================================================================
@@ -770,6 +955,33 @@ class GengoWatcherApp(App):
         # Setup logging redirection
         self._setup_logging()
 
+        # Register callback for when new jobs are detected
+        self.watcher.on_job_added_callback = self._on_job_added_from_thread
+
+    def _on_job_added_from_thread(self, job_data: dict):
+        """Called from watcher thread when a new job is added."""
+        # Use call_from_thread to safely update UI from watcher thread
+        self.call_from_thread(self._refresh_all_panels)
+
+    def _refresh_all_panels(self):
+        """Refresh all data panels when a new job is detected."""
+        try:
+            # Dashboard widgets
+            self.query_one(MetricsRow).refresh_metrics()
+            self.query_one(JobsPreview).refresh_jobs()
+            self.query_one(JobsHourChart).refresh_chart()
+            self.query_one(SessionStats).refresh_stats()
+        except NoMatches:
+            pass
+
+        try:
+            # Tab panels
+            self.query_one(JobsPanel).refresh_jobs()
+            self.query_one(ChartsPanel).refresh_charts()
+            self.query_one(StatsPanel).refresh_stats()
+        except NoMatches:
+            pass
+
     def _setup_logging(self):
         handler = TextualLogHandler(self)
         logging.getLogger().addHandler(handler)
@@ -795,15 +1007,15 @@ class GengoWatcherApp(App):
                     yield ActivityPreview()
 
             with TabPane("Jobs", id="jobs"):
-                yield DataTable(id="jobs-table-full")
+                yield JobsPanel(state=self.state)
             with TabPane("Activity", id="activity"):
                 yield RichLog(id="activity-log-full", markup=True)
             with TabPane("Output", id="output"):
                 yield RichLog(id="output-log", markup=True)
             with TabPane("Charts", id="charts"):
-                yield Static("Charts Content")
+                yield ChartsPanel(stats=self.stats, state=self.state)
             with TabPane("Stats", id="stats"):
-                yield Static("Stats Content")
+                yield StatsPanel(stats=self.stats)
 
         # 3. Input & Footer
         yield Input(placeholder="> help_")
@@ -901,12 +1113,26 @@ class TextualLogHandler(logging.Handler):
             pass  # Logging failures should not crash the app
 
     def write_log(self, msg: str, level: int = logging.INFO):
+        colored_text = self._colorize_message(msg, level)
+        # Write to dashboard activity log
         try:
             log = self.app.query_one("#activity-log", RichLog)
-            colored_text = self._colorize_message(msg, level)
             log.write(colored_text)
         except NoMatches:
             pass  # Widget not mounted yet
+        # Also write to full activity log tab
+        try:
+            log_full = self.app.query_one("#activity-log-full", RichLog)
+            log_full.write(colored_text)
+        except NoMatches:
+            pass  # Widget not mounted yet
+        # Also write to output log for system output
+        if level >= logging.WARNING:
+            try:
+                output_log = self.app.query_one("#output-log", RichLog)
+                output_log.write(colored_text)
+            except NoMatches:
+                pass  # Widget not mounted yet
 
     def _colorize_message(self, msg: str, level: int) -> Text:
         """Apply Rich markup coloring based on content patterns."""

--- a/src/gengowatcher/ui_textual.py
+++ b/src/gengowatcher/ui_textual.py
@@ -789,6 +789,8 @@ class JobsPanel(Static):
                     elif " " in timestamp:
                         timestamp = timestamp.split(" ")[1][:8]
                     else:
+                        # Fallback: timestamp is assumed to already be a time-like string
+                        # (e.g. "12:34:56"); truncate to 8 chars to enforce "HH:MM:SS".
                         timestamp = timestamp[:8]
                 else:
                     timestamp = ""

--- a/src/gengowatcher/watcher.py
+++ b/src/gengowatcher/watcher.py
@@ -47,6 +47,11 @@ PLACEHOLDER_CONFIG_VALUES = {
 }
 
 SENSITIVE_KEYWORDS = {"password", "session", "key"}
+LANG_PAIR_REGEX = re.compile(
+    r"\b([A-Z]{2})\s*(?:→|->|-|>)\s*([A-Z]{2})\b", re.IGNORECASE
+)
+LANG_PAIR_SPLIT_REGEX = re.compile(r"\s*(?:→|->|-|>|↔|/)\s*")
+WORD_COUNT_REGEX = re.compile(r"\b(\d{1,6})\s*words?\b", re.IGNORECASE)
 
 
 class GengoWatcher:
@@ -341,7 +346,7 @@ class GengoWatcher:
             )
         self._all_entries_log_file.flush()
 
-    def _process_new_job(self, job_id, title, reward, url, source):
+    def _process_new_job(self, job_id, title, reward, url, source, source_meta=None):
         """Process a newly discovered job from RSS or WebSocket sources.
 
         Handles job filtering, notification, storage, and auto-acceptance logic.
@@ -353,6 +358,7 @@ class GengoWatcher:
             reward: Job reward amount in USD.
             url: URL to access the job.
             source: Source of the job discovery ("RSS" or "WebSocket").
+            source_meta: Optional metadata from the source (entry dict, websocket payload, etc.).
         """
         self.logger.debug(
             f"Processing new job: {job_id}, {title}, {reward}, {url}, {source}"
@@ -383,6 +389,9 @@ class GengoWatcher:
             url=url,
         )
 
+        lang_pair = self._derive_lang_pair(title, source_meta)
+        word_count = self._derive_word_count(title, source_meta)
+
         # Prepare job data for storage, callbacks, and acceptance checks
         job_data = {
             "id": str(job_id),
@@ -392,6 +401,8 @@ class GengoWatcher:
             "url": url,
             "timestamp": time.time(),
             "source": source,
+            "lang_pair": lang_pair,
+            "word_count": word_count,
         }
         try:
             self.state.add_job(job_data)
@@ -431,27 +442,7 @@ class GengoWatcher:
         self.state.save_state()
 
         # Notify UI that a new job was added, but only if it was stored in state
-        job_in_state = False
-        try:
-            jobs_attr = getattr(self.state, "jobs", None)
-            if isinstance(jobs_attr, dict):
-                job_in_state = job_id in jobs_attr or str(job_id) in jobs_attr
-            elif isinstance(jobs_attr, list):
-                for job in jobs_attr:
-                    job_id_in_state = None
-                    if isinstance(job, dict):
-                        job_id_in_state = job.get("id")
-                    else:
-                        job_id_in_state = getattr(job, "id", None)
-                    if job_id_in_state is not None and (
-                        job_id_in_state == job_id
-                        or str(job_id_in_state) == str(job_id)
-                    ):
-                        job_in_state = True
-                        break
-        except Exception as e:
-            self.logger.debug(f"Error while verifying job presence in state: {e}")
-            job_in_state = False
+        job_in_state = self.job_in_state(job_id)
 
         if self.on_job_added_callback and job_in_state:
             try:
@@ -463,6 +454,110 @@ class GengoWatcher:
             self.logger.debug(
                 f"Skipping job added callback for job {job_id} because it was not stored in state"
             )
+
+    def job_in_state(self, job_id) -> bool:
+        """Return True if the job ID is present in the persisted state."""
+
+        try:
+            target_id = str(job_id)
+        except Exception:
+            return False
+
+        try:
+            jobs = self.state.get_recent_jobs(limit=AppState.MAX_STORED_JOBS)
+        except Exception as error:
+            self.logger.debug(f"Failed to load recent jobs for lookup: {error}")
+            return False
+
+        for job in jobs:
+            if str(job.get("id")) == target_id:
+                return True
+        return False
+
+    def _normalize_meta(self, meta) -> dict:
+        if meta is None or not hasattr(meta, "get"):
+            return {}
+        return meta
+
+    def _pick_meta_value(self, meta: dict, keys: list[str]):
+        for key in keys:
+            value = meta.get(key)
+            if value:
+                return value
+        return None
+
+    def _format_lang_token(self, token: str) -> str:
+        if not token:
+            return ""
+        cleaned = "".join(ch for ch in str(token) if ch.isalpha())
+        if not cleaned:
+            return ""
+        if len(cleaned) == 2:
+            return cleaned.upper()
+        return cleaned[:2].upper()
+
+    def _normalize_lang_pair_string(self, value) -> str:
+        if not value:
+            return ""
+        candidate = str(value)
+        parts = LANG_PAIR_SPLIT_REGEX.split(candidate)
+        if len(parts) < 2:
+            return ""
+        left = self._format_lang_token(parts[0])
+        right = self._format_lang_token(parts[1])
+        if left and right:
+            return f"{left}→{right}"
+        return ""
+
+    def _parse_lang_pair_from_title(self, title) -> str:
+        if not title:
+            return ""
+        text = str(title)
+        primary = text.split("|")[0]
+        match = LANG_PAIR_REGEX.search(primary)
+        if match:
+            return f"{match.group(1).upper()}→{match.group(2).upper()}"
+        return self._normalize_lang_pair_string(primary)
+
+    def _derive_lang_pair(self, title, source_meta) -> str:
+        meta = self._normalize_meta(source_meta)
+        for key in ("lang_pair", "language_pair"):
+            normalized = self._normalize_lang_pair_string(meta.get(key))
+            if normalized:
+                return normalized
+
+        src = self._pick_meta_value(
+            meta, ["lc_src", "source_lang", "source_language", "source"]
+        )
+        tgt = self._pick_meta_value(
+            meta, ["lc_tgt", "target_lang", "target_language", "target"]
+        )
+        if src and tgt:
+            left = self._format_lang_token(src)
+            right = self._format_lang_token(tgt)
+            if left and right:
+                return f"{left}→{right}"
+
+        fallback = self._parse_lang_pair_from_title(title)
+        return fallback or "??→??"
+
+    def _derive_word_count(self, title, source_meta) -> int:
+        meta = self._normalize_meta(source_meta)
+        for key in ("word_count", "words"):
+            if key in meta:
+                try:
+                    return int(meta.get(key))
+                except (TypeError, ValueError):
+                    continue
+
+        text = str(title) if title else ""
+        match = WORD_COUNT_REGEX.search(text)
+        if match:
+            try:
+                return int(match.group(1))
+            except ValueError:
+                pass
+        return 0
 
     def _async_job_acceptance_wrapper(self, job_data: dict):
         """
@@ -557,7 +652,14 @@ class GengoWatcher:
                     continue
                 job_id = int(match.group(1))
                 reward = self._extract_reward(entry)
-                self._process_new_job(job_id, title, reward, url, source="RSS")
+                self._process_new_job(
+                    job_id,
+                    title,
+                    reward,
+                    url,
+                    source="RSS",
+                    source_meta=entry,
+                )
             except (ValueError, IndexError) as e:
                 self.logger.warning(f"Error processing RSS entry {url}: {e}")
 
@@ -888,6 +990,7 @@ class GengoWatcher:
                                             reward,
                                             url,
                                             source="WebSocket",
+                                            source_meta=job,
                                         )
                                 else:
                                     self.logger.debug(

--- a/src/gengowatcher/watcher.py
+++ b/src/gengowatcher/watcher.py
@@ -14,6 +14,7 @@ import sys
 import threading
 import time
 import webbrowser
+from typing import Callable, Optional
 from collections import deque
 from pathlib import Path
 
@@ -120,6 +121,9 @@ class GengoWatcher:
         )
         if self.config.get("Logging", "log_all_entries_enabled"):
             self._setup_csv_logging()
+
+        # Callback for UI notification when a new job is added (set by UI)
+        self.on_job_added_callback: Optional[Callable[[dict], None]] = None
 
         # Initialize job acceptance engine (without CAPTCHA support)
         self.job_acceptance_engine = JobAcceptanceEngine(
@@ -1083,7 +1087,14 @@ class GengoWatcher:
                     self.state.last_seen_rss_link = first_link
                     self.state.last_seen_link = first_link
                     self.logger.info("Initial RSS feed primed successfully.")
-                    self.state.save_state()
+        self.state.save_state()
+
+        # Notify UI that a new job was added
+        if self.on_job_added_callback:
+            try:
+                self.on_job_added_callback(job_data)
+            except Exception as e:
+                self.logger.debug(f"Error in job added callback: {e}")
 
         while not self.shutdown_event.is_set():
             is_paused = os.path.exists(self.PAUSE_FILE)

--- a/src/gengowatcher/watcher.py
+++ b/src/gengowatcher/watcher.py
@@ -428,6 +428,13 @@ class GengoWatcher:
 
         self.state.save_state()
 
+        # Notify UI that a new job was added
+        if self.on_job_added_callback:
+            try:
+                self.on_job_added_callback(job_data)
+            except Exception as e:
+                self.logger.debug(f"Error in job added callback: {e}")
+
     def _async_job_acceptance_wrapper(self, job_data: dict):
         """
         Wrapper to run async job acceptance in a separate thread.
@@ -1088,13 +1095,6 @@ class GengoWatcher:
                     self.state.last_seen_link = first_link
                     self.logger.info("Initial RSS feed primed successfully.")
         self.state.save_state()
-
-        # Notify UI that a new job was added
-        if self.on_job_added_callback:
-            try:
-                self.on_job_added_callback(job_data)
-            except Exception as e:
-                self.logger.debug(f"Error in job added callback: {e}")
 
         while not self.shutdown_event.is_set():
             is_paused = os.path.exists(self.PAUSE_FILE)

--- a/src/gengowatcher/watcher.py
+++ b/src/gengowatcher/watcher.py
@@ -428,12 +428,26 @@ class GengoWatcher:
 
         self.state.save_state()
 
-        # Notify UI that a new job was added
-        if self.on_job_added_callback:
+        # Notify UI that a new job was added, but only if it was stored in state
+        job_in_state = False
+        try:
+            jobs_attr = getattr(self.state, "jobs", None)
+            if isinstance(jobs_attr, dict):
+                job_in_state = job_id in jobs_attr or str(job_id) in jobs_attr
+        except Exception as e:
+            self.logger.debug(f"Error while verifying job presence in state: {e}")
+            job_in_state = False
+
+        if self.on_job_added_callback and job_in_state:
             try:
                 self.on_job_added_callback(job_data)
             except Exception as e:
                 self.logger.debug(f"Error in job added callback: {e}")
+        elif self.on_job_added_callback and not job_in_state:
+            # This can happen if storing the job in state failed earlier.
+            self.logger.debug(
+                f"Skipping job added callback for job {job_id} because it was not stored in state"
+            )
 
     def _async_job_acceptance_wrapper(self, job_data: dict):
         """

--- a/src/gengowatcher/watcher.py
+++ b/src/gengowatcher/watcher.py
@@ -436,6 +436,19 @@ class GengoWatcher:
             jobs_attr = getattr(self.state, "jobs", None)
             if isinstance(jobs_attr, dict):
                 job_in_state = job_id in jobs_attr or str(job_id) in jobs_attr
+            elif isinstance(jobs_attr, list):
+                for job in jobs_attr:
+                    job_id_in_state = None
+                    if isinstance(job, dict):
+                        job_id_in_state = job.get("id")
+                    else:
+                        job_id_in_state = getattr(job, "id", None)
+                    if job_id_in_state is not None and (
+                        job_id_in_state == job_id
+                        or str(job_id_in_state) == str(job_id)
+                    ):
+                        job_in_state = True
+                        break
         except Exception as e:
             self.logger.debug(f"Error while verifying job presence in state: {e}")
             job_in_state = False

--- a/src/gengowatcher/watcher.py
+++ b/src/gengowatcher/watcher.py
@@ -404,8 +404,10 @@ class GengoWatcher:
             "lang_pair": lang_pair,
             "word_count": word_count,
         }
+        job_added = False
         try:
             self.state.add_job(job_data)
+            job_added = True
         except Exception as e:
             self.logger.warning(f"Failed to store job in state: {e}")
 
@@ -442,37 +444,16 @@ class GengoWatcher:
         self.state.save_state()
 
         # Notify UI that a new job was added, but only if it was stored in state
-        job_in_state = self.job_in_state(job_id)
-
-        if self.on_job_added_callback and job_in_state:
+        if self.on_job_added_callback and job_added:
             try:
                 self.on_job_added_callback(job_data)
             except Exception as e:
                 self.logger.debug(f"Error in job added callback: {e}")
-        elif self.on_job_added_callback and not job_in_state:
+        elif self.on_job_added_callback and not job_added:
             # This can happen if storing the job in state failed earlier.
             self.logger.debug(
                 f"Skipping job added callback for job {job_id} because it was not stored in state"
             )
-
-    def job_in_state(self, job_id) -> bool:
-        """Return True if the job ID is present in the persisted state."""
-
-        try:
-            target_id = str(job_id)
-        except Exception:
-            return False
-
-        try:
-            jobs = self.state.get_recent_jobs(limit=AppState.MAX_STORED_JOBS)
-        except Exception as error:
-            self.logger.debug(f"Failed to load recent jobs for lookup: {error}")
-            return False
-
-        for job in jobs:
-            if str(job.get("id")) == target_id:
-                return True
-        return False
 
     def _normalize_meta(self, meta) -> dict:
         if meta is None or not hasattr(meta, "get"):
@@ -1212,12 +1193,14 @@ class GengoWatcher:
     def _run_rss_monitor(self):
         self.logger.debug("Starting RSS monitor thread.")
         self.logger.info("RSS monitor thread started.")
+        state_updated = False
         if not self.state.last_seen_rss_link:
             if self.state.last_seen_link:
                 self.state.last_seen_rss_link = self.state.last_seen_link
                 self.logger.debug(
                     "Migrated legacy last_seen_link value to last_seen_rss_link."
                 )
+                state_updated = True
             else:
                 self.rss_action = "Priming feed"
                 initial_feed = self.fetch_rss()
@@ -1226,7 +1209,9 @@ class GengoWatcher:
                     self.state.last_seen_rss_link = first_link
                     self.state.last_seen_link = first_link
                     self.logger.info("Initial RSS feed primed successfully.")
-        self.state.save_state()
+                    state_updated = True
+        if state_updated:
+            self.state.save_state()
 
         while not self.shutdown_event.is_set():
             is_paused = os.path.exists(self.PAUSE_FILE)

--- a/src/gengowatcher/watcher.py
+++ b/src/gengowatcher/watcher.py
@@ -1089,13 +1089,6 @@ class GengoWatcher:
                     self.logger.info("Initial RSS feed primed successfully.")
         self.state.save_state()
 
-        # Notify UI that a new job was added
-        if self.on_job_added_callback:
-            try:
-                self.on_job_added_callback(job_data)
-            except Exception as e:
-                self.logger.debug(f"Error in job added callback: {e}")
-
         while not self.shutdown_event.is_set():
             is_paused = os.path.exists(self.PAUSE_FILE)
             time_to_next_check = self.next_check_time - time.time()

--- a/src/gengowatcher/watcher.py
+++ b/src/gengowatcher/watcher.py
@@ -381,17 +381,17 @@ class GengoWatcher:
             url=url,
         )
 
-        # Store job in state for web API access
+        # Prepare job data for storage, callbacks, and acceptance checks
+        job_data = {
+            "id": str(job_id),
+            "title": title,
+            "reward": float(reward),
+            "currency": "USD",
+            "url": url,
+            "timestamp": time.time(),
+            "source": source,
+        }
         try:
-            job_data = {
-                "id": str(job_id),
-                "title": title,
-                "reward": float(reward),
-                "currency": "USD",
-                "url": url,
-                "timestamp": time.time(),
-                "source": source,
-            }
             self.state.add_job(job_data)
         except Exception as e:
             self.logger.warning(f"Failed to store job in state: {e}")

--- a/tests/test_dashboard_quadrants.py
+++ b/tests/test_dashboard_quadrants.py
@@ -4,7 +4,12 @@ import pytest
 from unittest.mock import MagicMock
 from textual.app import App, ComposeResult
 
-from gengowatcher.ui_textual import ActivityPreview, JobsPreview, ConfigPreview
+from gengowatcher.ui_textual import (
+    ActivityPreview,
+    JobsPreview,
+    ConfigPreview,
+    JobsPanel,
+)
 
 
 class ActivityPreviewTestApp(App):
@@ -30,7 +35,15 @@ class ConfigPreviewTestApp(App):
         yield ConfigPreview(self._config)
 
 
-@pytest.mark.asyncio
+class JobsPanelTestApp(App):
+    def __init__(self, state):
+        super().__init__()
+        self._state = state
+
+    def compose(self) -> ComposeResult:
+        yield JobsPanel(self._state)
+
+
 async def test_activity_preview_has_log():
     """ActivityPreview should have a RichLog widget."""
     app = ActivityPreviewTestApp()
@@ -126,3 +139,52 @@ async def test_config_preview_render_uses_constants():
         assert "..." in result_str
         # Verify the full 30-character value is not present
         assert "x" * 30 not in result_str
+
+
+@pytest.mark.asyncio
+async def test_jobs_preview_falls_back_to_title_fields():
+    state = MagicMock()
+    state.get_recent_jobs.return_value = [
+        {
+            "id": "123456",
+            "title": "JA→EN | 120 words | Sample",
+            "reward": 12.50,
+        }
+    ]
+
+    app = JobsPreviewTestApp(state)
+    async with app.run_test() as pilot:
+        preview = app.query_one(JobsPreview)
+        table = preview.query_one("#jobs-table")
+        table.add_row = MagicMock()
+        preview.refresh_jobs()
+        await pilot.pause()
+
+        args = table.add_row.call_args[0]
+        assert args[1] == "JA→EN"
+        assert args[2] == "120"
+
+
+@pytest.mark.asyncio
+async def test_jobs_panel_falls_back_to_title_fields():
+    state = MagicMock()
+    state.get_recent_jobs.return_value = [
+        {
+            "id": "1234567890",
+            "title": "EN-JA 350 words | Sample",
+            "reward": 8.25,
+            "source": "rss",
+        }
+    ]
+
+    app = JobsPanelTestApp(state)
+    async with app.run_test() as pilot:
+        panel = app.query_one(JobsPanel)
+        table = panel.query_one("#jobs-table-full")
+        table.add_row = MagicMock()
+        panel.refresh_jobs()
+        await pilot.pause()
+
+        args = table.add_row.call_args[0]
+        assert args[1] == "EN→JA"
+        assert args[2] == "350"

--- a/tests/test_stats_manager.py
+++ b/tests/test_stats_manager.py
@@ -44,6 +44,7 @@ def test_stats_manager_persistence():
         # Second manager - reload
         manager2 = StatsManager(stats_path=path)
         assert manager2.all_time.total_jobs == 100
+        assert manager2.all_time.total_jobs_accepted == 1
         assert manager2.by_source.email == 1
 
 
@@ -66,7 +67,8 @@ def test_stats_manager_accepted_vs_total():
         assert manager.all_time.total_jobs_accepted == 3
         # Check that total_value only includes accepted jobs (10 + 15 + 25 = 50)
         assert manager.all_time.total_value == 50.0
-        # Check that avg_job_value is calculated correctly (50 / 3 = 16.666...)
-        assert abs(manager.all_time.avg_job_value - 16.666666666666668) < 0.001
+        # Check that avg_job_value is calculated correctly (50 / 3)
+        expected_avg = 50.0 / 3
+        assert abs(manager.all_time.avg_job_value - expected_avg) < 0.001
 
 

--- a/tests/test_stats_manager.py
+++ b/tests/test_stats_manager.py
@@ -66,4 +66,7 @@ def test_stats_manager_accepted_vs_total():
         assert manager.all_time.total_jobs_accepted == 3
         # Check that total_value only includes accepted jobs (10 + 15 + 25 = 50)
         assert manager.all_time.total_value == 50.0
+        # Check that avg_job_value is calculated correctly (50 / 3 = 16.666...)
+        assert abs(manager.all_time.avg_job_value - 16.666666666666668) < 0.001
+
 

--- a/tests/test_stats_manager.py
+++ b/tests/test_stats_manager.py
@@ -50,8 +50,6 @@ def test_stats_manager_persistence():
         assert manager2.by_source.email == 1
 
 
-def test_stats_manager_accepted_vs_total():
-    """StatsManager should track accepted jobs separately from total jobs."""
 def test_get_peak_hour_with_empty_data():
     """get_peak_hour() should return zero rate when hourly_counts is empty."""
 

--- a/tests/test_stats_manager.py
+++ b/tests/test_stats_manager.py
@@ -24,6 +24,8 @@ def test_stats_manager_record_job():
         assert manager.session.jobs_found == 1
         assert manager.session.jobs_accepted == 1
         assert manager.session.total_value == 10.0
+        assert manager.all_time.total_jobs == 1
+        assert manager.all_time.total_jobs_accepted == 1
         assert manager.by_source.websocket == 1
         assert manager.by_language["JA→EN"] == 1
 
@@ -43,3 +45,25 @@ def test_stats_manager_persistence():
         manager2 = StatsManager(stats_path=path)
         assert manager2.all_time.total_jobs == 100
         assert manager2.by_source.email == 1
+
+
+def test_stats_manager_accepted_vs_total():
+    """StatsManager should track accepted jobs separately from total jobs."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = pathlib.Path(tmpdir) / "stats.json"
+        manager = StatsManager(stats_path=path)
+
+        # Record 5 jobs: 3 accepted, 2 not accepted
+        manager.record_job(10.0, "WebSocket", "JA→EN", accepted=True)
+        manager.record_job(15.0, "WebSocket", "JA→EN", accepted=True)
+        manager.record_job(20.0, "Email", "EN→JA", accepted=False)
+        manager.record_job(25.0, "WebSocket", "JA→EN", accepted=True)
+        manager.record_job(30.0, "Email", "EN→JA", accepted=False)
+
+        # Check that total_jobs counts all jobs (5)
+        assert manager.all_time.total_jobs == 5
+        # Check that total_jobs_accepted counts only accepted jobs (3)
+        assert manager.all_time.total_jobs_accepted == 3
+        # Check that total_value only includes accepted jobs (10 + 15 + 25 = 50)
+        assert manager.all_time.total_value == 50.0
+

--- a/tests/test_ui_textual.py
+++ b/tests/test_ui_textual.py
@@ -80,7 +80,7 @@ def test_sources_breakdown_normalizes_sources():
     panel.refresh_sources()
 
     mock_static.update.assert_called_once_with(
-        "WS: 20%\nEmail: 20%\nWebsite: 20%\nRSS: 20%"
+        "WS: 20%\nEmail: 20%\nWebsite: 20%\nRSS: 20%\nUnknown: 20%"
     )
 
 

--- a/tests/test_ui_textual.py
+++ b/tests/test_ui_textual.py
@@ -1,0 +1,104 @@
+"""Unit tests for shared helpers in the textual UI."""
+
+import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from textual.css.query import NoMatches
+
+from gengowatcher.ui_textual import (
+    ChartsPanel,
+    SourcesBreakdown,
+    TextualLogHandler,
+    _format_timestamp,
+    _normalize_source,
+)
+
+
+class DummyState:
+    def get_recent_jobs(self, limit):
+        return [{"reward": float(i)} for i in range(limit)]
+
+
+class DummySourceState:
+    def __init__(self, jobs):
+        self._jobs = jobs
+
+    def get_recent_jobs(self, limit):
+        return self._jobs[:limit]
+
+
+def test_format_timestamp_handles_various_formats():
+    epoch = 1672531200
+    expected = datetime.datetime.fromtimestamp(epoch).strftime("%H:%M:%S")
+    assert _format_timestamp(epoch) == expected
+    assert _format_timestamp("2024-01-01T12:34:56Z") == "12:34:56"
+    assert _format_timestamp("2024-01-01 03:02:01") == "03:02:01"
+    assert _format_timestamp("03:02:01.123") == "03:02:01"
+    assert _format_timestamp("") == ""
+    assert _format_timestamp(None) == ""
+
+
+@pytest.mark.parametrize(
+    "source,expected",
+    [
+        ("WebSocket", "websocket"),
+        ("ws", "websocket"),
+        ("EMAIL", "email"),
+        ("imap", "email"),
+        ("rss feed", "rss"),
+        ("https://example.com", "website"),
+        ("", "unknown"),
+        (None, "unknown"),
+    ],
+)
+def test_normalize_source_maps_known_buckets(source, expected):
+    assert _normalize_source(source) == expected
+
+
+def test_value_trend_limits_to_20_jobs():
+    panel = ChartsPanel(stats=None, state=DummyState())
+    text = panel._render_value_trend()
+    lines = [line for line in text.plain.splitlines() if line.strip()]
+    assert len(lines) == 20
+
+
+def test_sources_breakdown_normalizes_sources():
+    jobs = [
+        {"source": "RSS"},
+        {"source": "WebSocket"},
+        {"source": "email"},
+        {"source": "website"},
+        {"source": "unknown"},
+    ]
+    state = DummySourceState(jobs)
+    panel = SourcesBreakdown(state=state)
+    mock_static = MagicMock()
+    panel.query_one = MagicMock(return_value=mock_static)
+
+    panel.refresh_sources()
+
+    mock_static.update.assert_called_once_with(
+        "WS: 20%\nEmail: 20%\nWebsite: 20%\nRSS: 20%"
+    )
+
+
+def test_textual_log_handler_write_to_log_handles_missing_widget():
+    app = MagicMock()
+    app.query_one.side_effect = NoMatches
+    handler = TextualLogHandler(app)
+
+    handler._write_to_log("#activity-log", handler._colorize_message("msg", 20))
+
+
+def test_textual_log_handler_write_to_log_writes_to_widget():
+    log_widget = MagicMock()
+    app = MagicMock()
+    app.query_one.return_value = log_widget
+    handler = TextualLogHandler(app)
+
+    colored_text = handler._colorize_message("msg", 20)
+    handler._write_to_log("#activity-log", colored_text)
+
+    log_widget.write.assert_called_once_with(colored_text)

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -139,13 +139,13 @@ def test_process_new_job_callback(watcher_instance):
     w.on_job_added_callback = mock_callback
     w.job_acceptance_engine.is_job_eligible = MagicMock(return_value=False)
     mock_state = w.state
-    
+
     mock_state.total_new_entries_found = 0
     mock_state.seen_job_ids = collections.deque(maxlen=50)
-    
+
     # Process a new job
     w._process_new_job(123, "New Job", 10.0, "http://example.com/123", "RSS")
-    
+
     # Verify callback was called with correct job_data
     assert mock_callback.call_count == 1
     call_args = mock_callback.call_args[0][0]
@@ -155,17 +155,43 @@ def test_process_new_job_callback(watcher_instance):
     assert call_args["url"] == "http://example.com/123"
     assert call_args["source"] == "RSS"
     assert "timestamp" in call_args
-    
+
     # Process a duplicate job - callback should not be called again
     w._process_new_job(123, "New Job", 10.0, "http://example.com/123", "RSS")
     assert mock_callback.call_count == 1
-    
+
     # Process another new job - callback should be called again
     w._process_new_job(456, "Another Job", 5.0, "http://example.com/456", "WebSocket")
     assert mock_callback.call_count == 2
     call_args = mock_callback.call_args[0][0]
     assert call_args["id"] == "456"
     assert call_args["source"] == "WebSocket"
+
+
+def test_process_new_job_callback_order(watcher_instance):
+    """Ensure the job callback runs after the job is added to state."""
+    w = watcher_instance
+    w.show_notification = MagicMock()
+    events = []
+    recorded_job_data = []
+
+    def record_job_add(job_data):
+        events.append("add")
+        recorded_job_data.append(job_data)
+
+    callback = MagicMock(side_effect=lambda job_data: events.append("callback"))
+    w.state.add_job = MagicMock(side_effect=record_job_add)
+    w.on_job_added_callback = callback
+    w.job_acceptance_engine.is_job_eligible = MagicMock(return_value=False)
+    w.state.total_new_entries_found = 0
+    w.state.seen_job_ids = collections.deque(maxlen=50)
+
+    w._process_new_job(123, "Ordered Job", 8.0, "http://example.com/123", "RSS")
+
+    assert events == ["add", "callback"]
+    assert recorded_job_data
+    callback.assert_called_once()
+    assert recorded_job_data[0] is callback.call_args[0][0]
 
 
 def test_process_new_job_callback_exception_handling(watcher_instance):
@@ -176,13 +202,13 @@ def test_process_new_job_callback_exception_handling(watcher_instance):
     w.on_job_added_callback = mock_callback
     w.job_acceptance_engine.is_job_eligible = MagicMock(return_value=False)
     mock_state = w.state
-    
+
     mock_state.total_new_entries_found = 0
     mock_state.seen_job_ids = collections.deque(maxlen=50)
-    
+
     # Process a new job - should not raise exception despite callback error
     w._process_new_job(123, "New Job", 10.0, "http://example.com/123", "RSS")
-    
+
     # Verify callback was called
     assert mock_callback.call_count == 1
     # Verify job was still processed successfully

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -220,14 +220,44 @@ def test_process_new_job_callback_order(watcher_instance):
     assert recorded_job_data[0] is callback.call_args[0][0]
 
 
-def test_job_in_state_uses_get_recent_jobs(watcher_instance):
-    """job_in_state should rely on the public AppState API."""
+def test_process_new_job_skips_callback_when_add_fails(watcher_instance):
+    """Callback should not run if add_job raises an exception."""
     w = watcher_instance
-    job_id = "abc123"
-    w.state.get_recent_jobs = MagicMock(return_value=[{"id": job_id}])
+    w.show_notification = MagicMock()
+    mock_callback = MagicMock()
+    w.on_job_added_callback = mock_callback
+    w.job_acceptance_engine.is_job_eligible = MagicMock(return_value=False)
+    w.state.add_job = MagicMock(side_effect=Exception("boom"))
+    w.state.total_new_entries_found = 0
+    w.state.seen_job_ids = collections.deque(maxlen=50)
 
-    assert w.job_in_state(job_id)
-    w.state.get_recent_jobs.assert_called_once_with(limit=AppState.MAX_STORED_JOBS)
+    w._process_new_job(123, "New Job", 10.0, "http://example.com/123", "RSS")
+
+    assert mock_callback.call_count == 0
+
+
+def test_rss_monitor_saves_state_on_migration_only(watcher_instance):
+    """save_state should only run when priming or migrating RSS state."""
+    w = watcher_instance
+    w.shutdown_event.set()
+
+    w.state.last_seen_rss_link = "https://gengo.com/t/jobs/details/1/"
+    w.state.last_seen_link = None
+    w.state.save_state = MagicMock()
+
+    w._run_rss_monitor()
+
+    w.state.save_state.assert_not_called()
+
+    w.shutdown_event.clear()
+    w.shutdown_event.set()
+
+    w.state.last_seen_rss_link = None
+    w.state.last_seen_link = "https://gengo.com/t/jobs/details/2/"
+
+    w._run_rss_monitor()
+
+    w.state.save_state.assert_called_once()
 
 
 def test_process_new_job_callback_exception_handling(watcher_instance):

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -168,6 +168,32 @@ def test_process_new_job_callback(watcher_instance):
     assert call_args["source"] == "WebSocket"
 
 
+def test_process_new_job_populates_lang_pair_and_word_count(watcher_instance):
+    """Job data should contain normalized lang_pair and word_count."""
+    w = watcher_instance
+    w.show_notification = MagicMock()
+    recorded = []
+    w.state.add_job = MagicMock(side_effect=lambda data: recorded.append(data))
+    w.job_acceptance_engine.is_job_eligible = MagicMock(return_value=False)
+    w.state.total_new_entries_found = 0
+    w.state.seen_job_ids = collections.deque(maxlen=50)
+
+    source_meta = {"lc_src": "English", "lc_tgt": "Japanese", "word_count": "320"}
+    w._process_new_job(
+        999,
+        "English > Japanese | Sample",
+        15.0,
+        "http://example.com/999",
+        "RSS",
+        source_meta=source_meta,
+    )
+
+    assert recorded
+    job_data = recorded[0]
+    assert job_data["lang_pair"] == "EN→JA"
+    assert job_data["word_count"] == 320
+
+
 def test_process_new_job_callback_order(watcher_instance):
     """Ensure the job callback runs after the job is added to state."""
     w = watcher_instance
@@ -192,6 +218,16 @@ def test_process_new_job_callback_order(watcher_instance):
     assert recorded_job_data
     callback.assert_called_once()
     assert recorded_job_data[0] is callback.call_args[0][0]
+
+
+def test_job_in_state_uses_get_recent_jobs(watcher_instance):
+    """job_in_state should rely on the public AppState API."""
+    w = watcher_instance
+    job_id = "abc123"
+    w.state.get_recent_jobs = MagicMock(return_value=[{"id": job_id}])
+
+    assert w.job_in_state(job_id)
+    w.state.get_recent_jobs.assert_called_once_with(limit=AppState.MAX_STORED_JOBS)
 
 
 def test_process_new_job_callback_exception_handling(watcher_instance):

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -129,3 +129,62 @@ def test_process_new_job_deduplication(watcher_instance):
     assert mock_state.save_state.call_count == 2
     assert 456 in mock_state.seen_job_ids
     assert mock_state.total_new_entries_found == 2
+
+
+def test_process_new_job_callback(watcher_instance):
+    """Test that on_job_added_callback is invoked correctly with job_data."""
+    w = watcher_instance
+    w.show_notification = MagicMock()
+    mock_callback = MagicMock()
+    w.on_job_added_callback = mock_callback
+    w.job_acceptance_engine.is_job_eligible = MagicMock(return_value=False)
+    mock_state = w.state
+    
+    mock_state.total_new_entries_found = 0
+    mock_state.seen_job_ids = collections.deque(maxlen=50)
+    
+    # Process a new job
+    w._process_new_job(123, "New Job", 10.0, "http://example.com/123", "RSS")
+    
+    # Verify callback was called with correct job_data
+    assert mock_callback.call_count == 1
+    call_args = mock_callback.call_args[0][0]
+    assert call_args["id"] == "123"
+    assert call_args["title"] == "New Job"
+    assert call_args["reward"] == 10.0
+    assert call_args["url"] == "http://example.com/123"
+    assert call_args["source"] == "RSS"
+    assert "timestamp" in call_args
+    
+    # Process a duplicate job - callback should not be called again
+    w._process_new_job(123, "New Job", 10.0, "http://example.com/123", "RSS")
+    assert mock_callback.call_count == 1
+    
+    # Process another new job - callback should be called again
+    w._process_new_job(456, "Another Job", 5.0, "http://example.com/456", "WebSocket")
+    assert mock_callback.call_count == 2
+    call_args = mock_callback.call_args[0][0]
+    assert call_args["id"] == "456"
+    assert call_args["source"] == "WebSocket"
+
+
+def test_process_new_job_callback_exception_handling(watcher_instance):
+    """Test that exceptions in callback are caught and logged."""
+    w = watcher_instance
+    w.show_notification = MagicMock()
+    mock_callback = MagicMock(side_effect=Exception("Callback error"))
+    w.on_job_added_callback = mock_callback
+    w.job_acceptance_engine.is_job_eligible = MagicMock(return_value=False)
+    mock_state = w.state
+    
+    mock_state.total_new_entries_found = 0
+    mock_state.seen_job_ids = collections.deque(maxlen=50)
+    
+    # Process a new job - should not raise exception despite callback error
+    w._process_new_job(123, "New Job", 10.0, "http://example.com/123", "RSS")
+    
+    # Verify callback was called
+    assert mock_callback.call_count == 1
+    # Verify job was still processed successfully
+    assert 123 in mock_state.seen_job_ids
+    assert mock_state.total_new_entries_found == 1


### PR DESCRIPTION
- Add JobsPanel with full DataTable (ID, Lang Pair, Words, Reward, Source, Status, Time)
- Add ChartsPanel with hourly distribution, source breakdown, and value trend charts
- Wire up StatsPanel (was defined but unused) to Stats tab
- Route logs to Activity tab via activity-log-full
- Route warnings/errors to Output tab

- Remove timer-based refresh from StatsPanel, JobsPanel, ChartsPanel, JobsHourChart
- Add on_job_added_callback to watcher, called after _process_new_job
- Register callback in GengoWatcherApp to refresh all panels on job detection
- Preserve necessary timers (clock, status indicators, pulse animations)