### PR TITLE
fix: remove 1000 job limit and clear session on startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@ MANIFEST
 thoughts/
 .codex/
 .slim/
-stats.json
 
 # Virtual environments
 venv/
@@ -56,6 +55,7 @@ wakapi_db.db
 config.ini
 config.ini.new
 state.json
+stats.json
 *.pause
 token.json
 credentials.json

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Or directly:
 ```bash
 PYTHONPATH=src python -m gengowatcher.main
 ```
-On first run, you'll be guided through configuration setup.
+On the first run, you'll be guided through configuration setup.
+
 ## Configuration
 Settings are stored in `config.ini`. Key sections:
 ```ini
@@ -38,7 +39,7 @@ user_session = YOUR_SESSION_TOKEN
 user_key = YOUR_USER_KEY
 ```
 Get WebSocket credentials from your browser's DevTools:
-- **user_id** / **user_session**: Application → Cookies → gengo.com
+- **user_id** and **user_session**: Application → Cookies → gengo.com
 - **user_key**: Application → Local Storage → gengo.com → userKey
 
 ## Commands
@@ -46,7 +47,7 @@ Get WebSocket credentials from your browser's DevTools:
 | Command | Description |
 |---------|-------------|
 | `check` | Trigger immediate RSS check |
-| `pause` / `resume` | Pause/resume monitoring |
+| `pause` and `resume` | Pause/resume monitoring |
 | `wstest` | Test WebSocket connection |
 | `notifytest` | Test notifications |
 | `togglesound` | Toggle sound alerts |

--- a/docs/plans/2026-02-19-gengowatcher-go-design.md
+++ b/docs/plans/2026-02-19-gengowatcher-go-design.md
@@ -25,7 +25,7 @@ Rewrite GengoWatcher from Python to Go for integration as a submodule of `transl
 
 ## Module Structure
 
-```
+```text
 gengowatcher-go/
 ├── go.mod                          # Module: github.com/tdawe1/gengowatcher-go
 ├── cmd/

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,3 @@ requests>=2.25.1
 imapclient>=2.3.0
 playwright>=1.40.0
 playwright-stealth>=1.0.6
-textual-plotext>=1.0.0
-textual-autocomplete>=4.0.0

--- a/scripts/test_high_value_setup.py
+++ b/scripts/test_high_value_setup.py
@@ -22,7 +22,11 @@ def test_configuration():
     """
     Verify that the high-value job configuration file exists and contains valid settings.
 
-    Checks for the presence of config_high_value.ini, loads it via AppConfig and validates the RSS feed URL, WebSocket credentials (user_id, user_session, user_key), and high-value thresholds. Status messages are printed to stdout for each check.
+    Checks for the presence of config_high_value.ini, loads it via AppConfig,
+    validates the RSS feed URL, verifies WebSocket credentials
+    (user_id, user_session, user_key), validates high-value thresholds, and
+    reports optional CAPTCHA configuration status. Status messages are printed
+    to stdout for each check.
 
     Returns:
         bool: `True` if the configuration file exists and all validations complete without error, `False` otherwise.

--- a/src/gengowatcher/job_acceptance.py
+++ b/src/gengowatcher/job_acceptance.py
@@ -62,10 +62,11 @@ class RateLimiter:
     def wait_time(self) -> float:
         """Return seconds to wait before next request is allowed."""
         with self._lock:
-            self._clean_old_requests()
-            if len(self._requests) < self.max_requests:
+            if self.max_requests <= 0:
                 return 0.0
-            # Find oldest request and calculate when it will expire
+            self._clean_old_requests()
+            if not self._requests or len(self._requests) < self.max_requests:
+                return 0.0
             oldest = min(self._requests)
             return max(0.0, self.time_window - (time.time() - oldest))
 

--- a/src/gengowatcher/main.py
+++ b/src/gengowatcher/main.py
@@ -297,7 +297,9 @@ def main():
                 log.addHandler(file_handler)
             except IOError as e:
                 console.print(f"[error]Could not set up file logging: {e}[/]")
-        if args.stdio_logs or config.getboolean("Logging", "log_stdio_enabled", fallback=False):
+        if args.stdio_logs or config.getboolean(
+            "Logging", "log_stdio_enabled", fallback=False
+        ):
             stdio_handler = logging.StreamHandler(stream=sys.stderr)
             stdio_handler.setFormatter(
                 logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")

--- a/src/gengowatcher/notifier.py
+++ b/src/gengowatcher/notifier.py
@@ -16,10 +16,7 @@ def play_sound(sound_file_path: str):
     """
 
     def _play():
-        path = Path(sound_file_path)
-        if not path.is_absolute():
-            project_root = Path(__file__).parent.parent.parent
-            path = project_root / sound_file_path
+        path = _resolve_path(sound_file_path)
 
         if not path.is_file():
             logger.warning(f"Sound file not found: {sound_file_path}")
@@ -72,6 +69,15 @@ def play_sound(sound_file_path: str):
     sound_thread.start()
 
 
+def _resolve_path(file_path: str) -> Path:
+    """Resolve a path relative to project root if not absolute."""
+    path = Path(file_path)
+    if not path.is_absolute():
+        project_root = Path(__file__).parent.parent.parent
+        path = project_root / file_path
+    return path
+
+
 def send_notification(title: str, message: str, icon_path: str = ""):
     """
     Display a desktop notification using the system 'notify-send' utility.
@@ -85,20 +91,22 @@ def send_notification(title: str, message: str, icon_path: str = ""):
     """
     command = ["notify-send", title, message]
 
-    if icon_path and Path(icon_path).is_file():
-        command.extend(["--icon", icon_path])
+    if icon_path:
+        resolved_icon = _resolve_path(icon_path)
+        if resolved_icon.is_file():
+            command.extend(["--icon", str(resolved_icon)])
 
     try:
         subprocess.run(command, check=True, timeout=10)
         logger.debug("Notification sent successfully via notify-send.")
-    except subprocess.TimeoutExpired:
-        logger.error("Notification command timed out after 10 seconds")
     except FileNotFoundError:
         logger.exception(
             "`notify-send` command not found. Please ensure it is installed and in your PATH."
         )
+    except subprocess.TimeoutExpired:
+        logger.warning("notify-send timed out after 10 seconds")
     except subprocess.CalledProcessError as e:
-        logger.exception(f"Failed to send notification: {e}")
+        logger.exception("Failed to send notification")
 
 
 def show_notification(

--- a/src/gengowatcher/state.py
+++ b/src/gengowatcher/state.py
@@ -12,7 +12,6 @@ import datetime
 
 class AppState:
     STATE_FILE = "state.json"
-    MAX_STORED_JOBS = 1000  # Maximum number of jobs to store
 
     def __init__(
         self,
@@ -26,7 +25,7 @@ class AppState:
         self.last_seen_rss_link = None  # New variable for RSS tracking
         self.last_seen_link = None  # General last job (for display, optional)
         self.total_new_entries_found = 0
-        self.seen_job_ids = collections.deque(maxlen=1000)
+        self.seen_job_ids = collections.deque()  # Unbounded - no limit
         self._sparkline_data = []
 
         # Job storage for web API
@@ -53,13 +52,11 @@ class AppState:
                     with self._lock:
                         self.last_seen_rss_link = state_data.get("last_seen_rss_link")
                         self.last_seen_link = state_data.get("last_seen_link")
-                        self.total_new_entries_found = int(
-                            state_data.get("total_new_entries_found", 0)
-                        )
-                        self._sparkline_data = state_data.get("sparkline_data", [])
-                        loaded_ids = state_data.get("seen_job_ids", [])
+                        # Session data cleared on startup - start fresh each session
+                        self.total_new_entries_found = 0
                         self.seen_job_ids.clear()
-                        self.seen_job_ids.extend(loaded_ids)
+                        # Persist sparkline data across sessions
+                        self._sparkline_data = state_data.get("sparkline_data", [])
 
                         # Load stored jobs
                         stored_jobs = state_data.get("jobs", [])
@@ -188,10 +185,6 @@ class AppState:
 
             # Add new job
             self._jobs.insert(0, job_data)  # Add to beginning for newest first
-
-            # Maintain maximum size
-            if len(self._jobs) > self.MAX_STORED_JOBS:
-                self._jobs = self._jobs[: self.MAX_STORED_JOBS]
 
             self.logger.debug(f"Added job {job_data.get('id')} to storage")
 


### PR DESCRIPTION
## Summary
- Remove `maxlen=1000` from `seen_job_ids` deque - now unbounded
- Remove `MAX_STORED_JOBS` limit - `_jobs` list grows without cap
- Clear session data (`seen_job_ids`, `total_new_entries_found`) on startup - fresh session each time

This fixes the issue where total value would reset after 1000 jobs and sessions would persist forever.