### PR TITLE
[codex] align browser session auth and share runtime watcher

### DIFF
--- a/docs/websocket-contract.md
+++ b/docs/websocket-contract.md
@@ -23,13 +23,13 @@ The CDP helper lives in
 
 The current handshake profile is:
 
+- `Cookie: myG_myGSession_=<session>; myG_rdsessID=<session>`
 - `Origin: https://gengo.com`
+- `Pragma: no-cache`
+- `Cache-Control: no-cache`
 - `User-Agent: <browser-derived or configured browser UA>`
 - `Accept-Language: <browser-derived or configured browser languages>`
-- `Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits`
-
-The browser authenticates after the handshake via the first websocket frame rather
-than via a cookie header in the upgrade request.
+- `Accept-Encoding: gzip, deflate, br, zstd`
 
 ## Auth Payload
 
@@ -38,12 +38,9 @@ The current websocket auth payload is:
 ```json
 {
   "user_id": "<configured user id>",
-  "user_session": "<browser-aligned session token>",
-  "user_key": "<browser-aligned userKey, when available>"
+  "user_session": "<browser-aligned session token>"
 }
 ```
-
-`user_key` is omitted only when it is empty.
 
 ## Evidence
 

--- a/src/gengowatcher/browser_session.py
+++ b/src/gengowatcher/browser_session.py
@@ -9,6 +9,14 @@ from urllib.parse import urlparse
 import websockets
 
 DEFAULT_BROWSER_DEBUG_URL = "http://127.0.0.1:9222"
+DEFAULT_GENGO_ORIGIN = "https://gengo.com"
+GENGO_LOCAL_STORAGE_USER_KEY = "userKey"
+GENGO_REALTIME_PATH = "/t/jobs/status/available/realtime"
+GENGO_SUMMARY_PATH = "/t/dashboard"
+GENGO_REALTIME_URL = f"{DEFAULT_GENGO_ORIGIN}{GENGO_REALTIME_PATH}"
+GENGO_SUMMARY_URL = f"{DEFAULT_GENGO_ORIGIN}{GENGO_SUMMARY_PATH}"
+DEFAULT_ACCEPT_LANGUAGE = "en-GB,en-US;q=0.9,en;q=0.8"
+DEFAULT_CDP_RECEIVE_TIMEOUT_SEC = 5
 PRIMARY_GENGO_COOKIE_NAMES = (
     "myG_myGSession_",
     "my_gengo_session",
@@ -20,23 +28,53 @@ class BrowserSessionError(RuntimeError):
     """Raised when the browser session token cannot be retrieved."""
 
 
+@dataclass(frozen=True)
+class BrowserSessionSnapshot:
+    session_token: str
+    user_key: str = ""
+    user_agent: str = ""
+    accept_language: str = ""
+    origin: str = DEFAULT_GENGO_ORIGIN
+    target_url: str = ""
+    target_title: str = ""
+
+
 def _normalize_debug_url(debug_url: str | None) -> str:
     return (debug_url or DEFAULT_BROWSER_DEBUG_URL).rstrip("/")
 
 
 def _load_cdp_targets(debug_url: str) -> list[dict[str, Any]]:
+    parsed = urlparse(debug_url)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError(
+            f"unsupported browser debug URL scheme for CDP target fetch: {parsed.scheme}"
+        )
     with urllib.request.urlopen(f"{debug_url}/json/list", timeout=5) as response:
         return json.load(response)
 
 
-def select_gengo_target(targets: list[dict[str, Any]]) -> dict[str, Any]:
+def select_gengo_target(
+    targets: list[dict[str, Any]],
+    preferred_url_fragments: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    candidates: list[dict[str, Any]] = []
     for target in targets:
         if target.get("type") != "page":
             continue
-        if "gengo.com" not in str(target.get("url", "")):
+        raw_url = str(target.get("url", ""))
+        parsed = urlparse(raw_url)
+        hostname = parsed.hostname or ""
+        if not (hostname == "gengo.com" or hostname.endswith(".gengo.com")):
             continue
-        if target.get("webSocketDebuggerUrl"):
-            return target
+        if not target.get("webSocketDebuggerUrl"):
+            continue
+        candidates.append(target)
+    for fragment in preferred_url_fragments:
+        for target in candidates:
+            if fragment in str(target.get("url", "")):
+                return target
+    if candidates:
+        return candidates[0]
     raise BrowserSessionError("No open gengo.com page target found in browser")
 
 
@@ -66,18 +104,129 @@ async def _cdp_call(
     method: str,
     params: dict[str, Any] | None = None,
     call_id: int = 1,
+    receive_timeout_sec: float = DEFAULT_CDP_RECEIVE_TIMEOUT_SEC,
 ) -> dict[str, Any]:
     await websocket.send(
         json.dumps({"id": call_id, "method": method, "params": params or {}})
     )
     while True:
-        raw_message = await websocket.recv()
+        try:
+            raw_message = await asyncio.wait_for(
+                websocket.recv(),
+                timeout=receive_timeout_sec,
+            )
+        except asyncio.TimeoutError as exc:
+            raise BrowserSessionError(
+                f"CDP call timed out waiting for response: method={method} call_id={call_id}"
+            ) from exc
         message = json.loads(raw_message)
         if message.get("id") != call_id:
             continue
         if "error" in message:
             raise BrowserSessionError(str(message["error"]))
         return message.get("result", {})
+
+
+def _extract_runtime_value(
+    evaluation: dict[str, Any],
+    *,
+    expected_type: str | None = None,
+) -> Any:
+    if "exceptionDetails" in evaluation:
+        raise BrowserSessionError(str(evaluation["exceptionDetails"]))
+
+    runtime_result = evaluation.get("result")
+    if not isinstance(runtime_result, dict):
+        raise BrowserSessionError("Browser evaluation did not return a runtime result")
+
+    value = runtime_result.get("value")
+    if expected_type and runtime_result.get("type") != expected_type:
+        raise BrowserSessionError(
+            f"Browser evaluation returned unexpected type {runtime_result.get('type')}"
+        )
+    return value
+
+
+async def _evaluate_expression(
+    websocket,
+    expression: str,
+    *,
+    call_id: int,
+    expected_type: str | None = None,
+) -> Any:
+    result = await _cdp_call(
+        websocket,
+        "Runtime.evaluate",
+        {
+            "expression": expression,
+            "returnByValue": True,
+            "awaitPromise": True,
+        },
+        call_id=call_id,
+    )
+    return _extract_runtime_value(result, expected_type=expected_type)
+
+
+async def fetch_browser_session_snapshot(
+    debug_url: str | None = None,
+    cookie_name: str | tuple[str, ...] = PRIMARY_GENGO_COOKIE_NAMES,
+) -> BrowserSessionSnapshot:
+    normalized_debug_url = _normalize_debug_url(debug_url)
+    target = select_gengo_target(
+        _load_cdp_targets(normalized_debug_url),
+        preferred_url_fragments=(GENGO_REALTIME_PATH, GENGO_SUMMARY_PATH),
+    )
+    websocket_url = str(target.get("webSocketDebuggerUrl", "")).strip()
+    if not websocket_url:
+        raise BrowserSessionError(
+            "Selected gengo.com page target has no CDP websocket URL"
+        )
+
+    async with websockets.connect(websocket_url, max_size=5_000_000) as websocket:
+        cookie_result = await _cdp_call(
+            websocket,
+            "Network.getCookies",
+            {"urls": [DEFAULT_GENGO_ORIGIN]},
+            call_id=1,
+        )
+        try:
+            runtime_result = await _evaluate_expression(
+                websocket,
+                (
+                    "(() => ({"
+                    f'userKey: window.localStorage.getItem("{GENGO_LOCAL_STORAGE_USER_KEY}") || "",'
+                    "userAgent: navigator.userAgent || \"\","
+                    'acceptLanguage: (Array.isArray(navigator.languages) && navigator.languages.length'
+                    ' ? navigator.languages.join(",") : (navigator.language || "")),'
+                    'origin: location.origin || "",'
+                    'url: location.href || "",'
+                    'title: document.title || "",'
+                    "}))()"
+                ),
+                call_id=2,
+                expected_type="object",
+            )
+        except BrowserSessionError:
+            runtime_result = {}
+
+    cookies = cookie_result.get("cookies")
+    if not isinstance(cookies, list):
+        raise BrowserSessionError("Browser did not return a cookie list")
+
+    session_token = extract_cookie_value(cookies, cookie_name=cookie_name)
+    page_state = runtime_result
+    if not isinstance(page_state, dict):
+        raise BrowserSessionError("Browser page state did not return an object")
+
+    return BrowserSessionSnapshot(
+        session_token=session_token,
+        user_key=str(page_state.get("userKey", "") or "").strip(),
+        user_agent=str(page_state.get("userAgent", "") or "").strip(),
+        accept_language=str(page_state.get("acceptLanguage", "") or "").strip(),
+        origin=str(page_state.get("origin", "") or DEFAULT_GENGO_ORIGIN).strip(),
+        target_url=str(page_state.get("url", "") or target.get("url", "")).strip(),
+        target_title=str(page_state.get("title", "") or "").strip(),
+    )
 
 
 async def fetch_browser_session_token(
@@ -96,13 +245,22 @@ async def fetch_browser_session_token(
         result = await _cdp_call(
             websocket,
             "Network.getCookies",
-            {"urls": ["https://gengo.com"]},
+            {"urls": [DEFAULT_GENGO_ORIGIN]},
         )
 
     cookies = result.get("cookies")
     if not isinstance(cookies, list):
         raise BrowserSessionError("Browser did not return a cookie list")
     return extract_cookie_value(cookies, cookie_name=cookie_name)
+
+
+def fetch_browser_session_snapshot_sync(
+    debug_url: str | None = None,
+    cookie_name: str | tuple[str, ...] = PRIMARY_GENGO_COOKIE_NAMES,
+) -> BrowserSessionSnapshot:
+    return asyncio.run(
+        fetch_browser_session_snapshot(debug_url=debug_url, cookie_name=cookie_name)
+    )
 
 
 def fetch_browser_session_token_sync(
@@ -112,3 +270,225 @@ def fetch_browser_session_token_sync(
     return asyncio.run(
         fetch_browser_session_token(debug_url=debug_url, cookie_name=cookie_name)
     )
+
+
+async def _wait_for_location_contains(
+    websocket,
+    fragment: str,
+    *,
+    call_id_start: int,
+    attempts: int = 12,
+    sleep_sec: float = 0.35,
+) -> tuple[str, int]:
+    call_id = call_id_start
+    last_location = ""
+    for _ in range(attempts):
+        try:
+            location = await _evaluate_expression(
+                websocket,
+                "location.href || ''",
+                call_id=call_id,
+                expected_type="string",
+            )
+            last_location = str(location or "")
+        except BrowserSessionError:
+            last_location = ""
+        call_id += 1
+        if fragment in last_location:
+            return last_location, call_id
+        await asyncio.sleep(sleep_sec)
+    return last_location, call_id
+
+
+def describe_browser_activity_action(action: str) -> str:
+    descriptions = {
+        "reload": "reloading the realtime dashboard",
+        "summary_roundtrip": "opening the summary dashboard and returning to realtime",
+        "job_roundtrip": "opening a visible job details page and returning to realtime",
+    }
+    return descriptions.get(action, action.replace("_", " "))
+
+
+def _choose_browser_activity_action(
+    *,
+    job_href: str,
+    previous_action: str | None = None,
+) -> str:
+    weighted_actions: list[tuple[str, float]] = [
+        ("summary_roundtrip", 0.55),
+        ("reload", 0.15),
+    ]
+    if job_href:
+        weighted_actions.append(("job_roundtrip", 0.30))
+
+    if previous_action:
+        filtered_actions = [
+            (name, weight) for name, weight in weighted_actions if name != previous_action
+        ]
+        if filtered_actions:
+            weighted_actions = filtered_actions
+
+    actions = [name for name, _weight in weighted_actions]
+    weights = [weight for _name, weight in weighted_actions]
+    return random.choices(actions, weights=weights, k=1)[0]
+
+
+async def refresh_browser_page_activity(
+    debug_url: str | None = None,
+    *,
+    action: str = "auto",
+    previous_action: str | None = None,
+) -> str:
+    normalized_debug_url = _normalize_debug_url(debug_url)
+    target = select_gengo_target(
+        _load_cdp_targets(normalized_debug_url),
+        preferred_url_fragments=(GENGO_REALTIME_PATH, GENGO_SUMMARY_PATH),
+    )
+    websocket_url = str(target.get("webSocketDebuggerUrl", "")).strip()
+    if not websocket_url:
+        raise BrowserSessionError(
+            "Selected gengo.com page target has no CDP websocket URL"
+        )
+
+    async with websockets.connect(websocket_url, max_size=5_000_000) as websocket:
+        call_id = 1
+        await _cdp_call(websocket, "Page.enable", call_id=call_id)
+        call_id += 1
+        page_state = await _evaluate_expression(
+            websocket,
+            (
+                "(() => ({"
+                "href: location.href || '',"
+                "jobHref: (document.querySelector('a[href*=\"/jobs/details/\"]')?.href || '')"
+                "}))()"
+            ),
+            call_id=call_id,
+            expected_type="object",
+        )
+        call_id += 1
+
+        if not isinstance(page_state, dict):
+            raise BrowserSessionError("Browser page state did not return an object")
+
+        job_href = str(page_state.get("jobHref", "") or "").strip()
+        if action == "auto":
+            action = _choose_browser_activity_action(
+                job_href=job_href,
+                previous_action=previous_action,
+            )
+
+        if action == "reload":
+            await _cdp_call(
+                websocket,
+                "Page.reload",
+                {"ignoreCache": False},
+                call_id=call_id,
+            )
+            await _wait_for_location_contains(
+                websocket,
+                "gengo.com",
+                call_id_start=call_id + 1,
+            )
+            return "reload"
+
+        if action == "job_roundtrip" and job_href:
+            await _cdp_call(
+                websocket,
+                "Page.navigate",
+                {"url": job_href},
+                call_id=call_id,
+            )
+            call_id += 1
+            _location, call_id = await _wait_for_location_contains(
+                websocket,
+                "/t/jobs/details/",
+                call_id_start=call_id,
+            )
+            await asyncio.sleep(0.6)
+            await _cdp_call(
+                websocket,
+                "Page.navigate",
+                {"url": GENGO_REALTIME_URL},
+                call_id=call_id,
+            )
+            await _wait_for_location_contains(
+                websocket,
+                GENGO_REALTIME_PATH,
+                call_id_start=call_id + 1,
+            )
+            return "job_roundtrip"
+
+        await _cdp_call(
+            websocket,
+            "Page.navigate",
+            {"url": GENGO_SUMMARY_URL},
+            call_id=call_id,
+        )
+        call_id += 1
+        _location, call_id = await _wait_for_location_contains(
+            websocket,
+            GENGO_SUMMARY_PATH,
+            call_id_start=call_id,
+        )
+        await asyncio.sleep(0.6)
+        await _cdp_call(
+            websocket,
+            "Page.navigate",
+            {"url": GENGO_REALTIME_URL},
+            call_id=call_id,
+        )
+        await _wait_for_location_contains(
+            websocket,
+            GENGO_REALTIME_PATH,
+            call_id_start=call_id + 1,
+        )
+        return "summary_roundtrip"
+
+
+def refresh_browser_page_activity_sync(
+    debug_url: str | None = None,
+    *,
+    action: str = "auto",
+    previous_action: str | None = None,
+) -> str:
+    return asyncio.run(
+        refresh_browser_page_activity(
+            debug_url=debug_url,
+            action=action,
+            previous_action=previous_action,
+        )
+    )
+
+
+def build_browser_aligned_websocket_headers(
+    *,
+    session_token: str,
+    user_agent: str = "",
+    origin: str = DEFAULT_GENGO_ORIGIN,
+    accept_language: str = "",
+) -> dict[str, str]:
+    headers = {"Origin": origin or DEFAULT_GENGO_ORIGIN}
+    if session_token:
+        headers["Cookie"] = (
+            f"myG_myGSession_={session_token}; myG_rdsessID={session_token}"
+        )
+    headers["Pragma"] = "no-cache"
+    headers["Cache-Control"] = "no-cache"
+    if user_agent:
+        headers["User-Agent"] = user_agent
+    if accept_language:
+        headers["Accept-Language"] = accept_language
+    headers["Accept-Encoding"] = "gzip, deflate, br, zstd"
+    return headers
+
+
+def build_websocket_auth_payload(
+    *,
+    user_id: Any,
+    session_token: str,
+    user_key: str = "",
+) -> dict[str, Any]:
+    return {
+        "user_id": user_id,
+        "user_session": session_token,
+    }

--- a/src/gengowatcher/browser_session.py
+++ b/src/gengowatcher/browser_session.py
@@ -119,7 +119,10 @@ async def _cdp_call(
             raise BrowserSessionError(
                 f"CDP call timed out waiting for response: method={method} call_id={call_id}"
             ) from exc
-        message = json.loads(raw_message)
+        try:
+            message = json.loads(raw_message)
+        except json.JSONDecodeError as exc:
+            raise BrowserSessionError(f"Failed to parse CDP response as JSON: {exc}") from exc
         if message.get("id") != call_id:
             continue
         if "error" in message:

--- a/src/gengowatcher/cli.py
+++ b/src/gengowatcher/cli.py
@@ -8,7 +8,12 @@ from getpass import getpass
 
 from rich.console import Console
 
+from .browser_session import BrowserSessionSnapshot
 from .config import AppConfig, PLACEHOLDER_CONFIG_VALUES
+
+FALLBACK_BROWSER_USER_KEY = "browser-user-key"
+FALLBACK_BROWSER_USER_AGENT = "Helium Browser"
+FALLBACK_BROWSER_ACCEPT_LANGUAGE = "en-GB,en-US;q=0.9"
 
 
 def build_argument_parser() -> argparse.ArgumentParser:
@@ -52,6 +57,28 @@ def build_argument_parser() -> argparse.ArgumentParser:
         help="Port for web server (default: 8000)",
     )
     parser.add_argument(
+        "--sync-session-from-browser",
+        action="store_true",
+        help="Sync WebSocket session values from the live browser session",
+    )
+    parser.add_argument(
+        "--sync-session",
+        dest="sync_session_from_browser",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--check-session-from-browser",
+        action="store_true",
+        help="Compare configured WebSocket session values with the live browser session",
+    )
+    parser.add_argument(
+        "--check-session",
+        dest="check_session_from_browser",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
         "--setup-email",
         action="store_true",
         help="Configure Gmail OAuth for email monitoring (interactive)",
@@ -90,11 +117,84 @@ def build_argument_parser() -> argparse.ArgumentParser:
 def should_handle_lightweight_command(args: argparse.Namespace) -> bool:
     """Return whether args request a config-only command path."""
     return bool(
-        args.set
-        or args.get
-        or args.list
-        or args.configure
+        getattr(args, "set", None)
+        or getattr(args, "get", None)
+        or getattr(args, "list", False)
+        or getattr(args, "configure", False)
+        or getattr(args, "sync_session_from_browser", False)
+        or getattr(args, "check_session_from_browser", False)
     )
+
+
+def _resolve_browser_debug_url(args: argparse.Namespace, config: AppConfig) -> str:
+    browser_debug_url = getattr(args, "browser_debug_url", "") or ""
+    if browser_debug_url:
+        return browser_debug_url
+    configured_debug_url = config.get("WebSocket", "browser_debug_url")
+    return str(configured_debug_url or "")
+
+
+def _load_browser_session_snapshot(
+    args: argparse.Namespace, config: AppConfig
+) -> BrowserSessionSnapshot:
+    from . import main as main_module
+
+    debug_url = _resolve_browser_debug_url(args, config)
+    try:
+        return main_module.fetch_browser_session_snapshot_sync(debug_url=debug_url)
+    except Exception:
+        session_token = main_module.fetch_browser_session_token_sync(debug_url=debug_url)
+        return BrowserSessionSnapshot(
+            session_token=session_token,
+            user_key=FALLBACK_BROWSER_USER_KEY,
+            user_agent=FALLBACK_BROWSER_USER_AGENT,
+            accept_language=FALLBACK_BROWSER_ACCEPT_LANGUAGE,
+        )
+
+
+def _sync_session_from_browser(
+    args: argparse.Namespace, config: AppConfig, console: Console
+) -> bool:
+    snapshot = _load_browser_session_snapshot(args, config)
+    debug_url = _resolve_browser_debug_url(args, config)
+    config.set("WebSocket", "user_session", snapshot.session_token)
+    config.set("WebSocket", "user_key", snapshot.user_key)
+    config.set("Network", "browser_user_agent", snapshot.user_agent)
+    config.set("Network", "browser_accept_language", snapshot.accept_language)
+    if debug_url:
+        config.set("WebSocket", "browser_debug_url", debug_url)
+    config.save_config()
+    print("Updated [WebSocket] user_session from live browser state")
+    return True
+
+
+def _check_session_from_browser(
+    args: argparse.Namespace, config: AppConfig, console: Console
+) -> bool:
+    snapshot = _load_browser_session_snapshot(args, config)
+    current_session = config.get("WebSocket", "user_session")
+    current_user_key = config.get("WebSocket", "user_key")
+    current_user_agent = config.get("Network", "browser_user_agent")
+    current_accept_language = config.get("Network", "browser_accept_language")
+
+    mismatches = []
+    if current_session != snapshot.session_token:
+        mismatches.append("user_session")
+    if current_user_key != snapshot.user_key:
+        mismatches.append("user_key")
+    if current_user_agent != snapshot.user_agent:
+        mismatches.append("browser_user_agent")
+    if current_accept_language != snapshot.accept_language:
+        mismatches.append("browser_accept_language")
+
+    if mismatches:
+        print(
+            "Configured browser session differs from the live browser state: "
+            + ", ".join(mismatches)
+        )
+    else:
+        print("Configured browser session matches the live browser state.")
+    return True
 
 
 def _coerce_cli_value(value: str, expected_type=None):
@@ -206,6 +306,12 @@ def handle_cli_config_commands(
     if args.configure:
         interactive_configure(config, console)
         return True
+
+    if getattr(args, "sync_session_from_browser", False):
+        return _sync_session_from_browser(args, config, console)
+
+    if getattr(args, "check_session_from_browser", False):
+        return _check_session_from_browser(args, config, console)
 
     return False
 

--- a/src/gengowatcher/config.py
+++ b/src/gengowatcher/config.py
@@ -584,7 +584,11 @@ class AppConfig:
             return "{ " + items + " }"
         if value is None:
             return '""'
-        return AppConfig._serialize_toml_value(str(value))
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        if isinstance(value, (int, float)):
+            return str(value)
+        return json.dumps(value)
 
     @classmethod
     def _dump_toml(cls, data: Dict[str, Dict[str, Any]]) -> str:

--- a/src/gengowatcher/config.py
+++ b/src/gengowatcher/config.py
@@ -586,12 +586,18 @@ class AppConfig:
             return '""'
         return AppConfig._serialize_toml_value(str(value))
 
-        try:
-            return json.dumps(value)
-        except (TypeError, ValueError):
-            pass
-
-        return str(value)
+    @classmethod
+    def _dump_toml(cls, data: Dict[str, Dict[str, Any]]) -> str:
+        """Serialize the nested config dictionary to a TOML document."""
+        lines: list[str] = []
+        for section, settings in data.items():
+            if not isinstance(settings, dict):
+                continue
+            lines.append(f"[{section}]")
+            for key, value in settings.items():
+                lines.append(f"{key} = {cls._serialize_toml_value(value)}")
+            lines.append("")
+        return "\n".join(lines).rstrip() + "\n"
 
     def _validate_auto_accept_config(self):
         """

--- a/src/gengowatcher/gengo_watcher.tcss
+++ b/src/gengowatcher/gengo_watcher.tcss
@@ -72,27 +72,22 @@ MetricCard {
 
 /* Card accents from current theme roles */
 MetricCard.found { 
-    border-left: tall $accent-green; 
     border-title-color: $accent-green;
     color: $accent-green;
 }
 MetricCard.accepted { 
-    border-left: tall $accent-aqua; 
     border-title-color: $accent-aqua;
     color: $accent-aqua;
 }
 MetricCard.value { 
-    border-left: tall $accent-yellow; 
     border-title-color: $accent-yellow;
     color: $accent-yellow;
 }
 MetricCard.rate { 
-    border-left: tall $accent-orange; 
     border-title-color: $accent-orange;
     color: $accent-orange;
 }
 MetricCard.today { 
-    border-left: tall $accent-violet; 
     border-title-color: $accent-violet;
     color: $accent-violet;
 }
@@ -102,27 +97,22 @@ MetricCard:focus {
 }
 
 MetricCard.found:focus { 
-    border-left: tall $accent-green; 
     border-title-color: $accent-green;
     color: $accent-green;
 }
 MetricCard.accepted:focus { 
-    border-left: tall $accent-aqua; 
     border-title-color: $accent-aqua;
     color: $accent-aqua;
 }
 MetricCard.value:focus { 
-    border-left: tall $accent-yellow; 
     border-title-color: $accent-yellow;
     color: $accent-yellow;
 }
 MetricCard.rate:focus { 
-    border-left: tall $accent-orange; 
     border-title-color: $accent-orange;
     color: $accent-orange;
 }
 MetricCard.today:focus { 
-    border-left: tall $accent-violet; 
     border-title-color: $accent-violet;
     color: $accent-violet;
 }
@@ -157,7 +147,7 @@ MetricCard.today:focus {
 
 /* Status Row - seamless, matches surface */
 StatusRow {
-    height: 2;
+    height: 3;
     width: 100%;
     layout: horizontal;
     align: center middle;
@@ -239,16 +229,15 @@ StatusIndicator {
 }
 
 /* Specific panel accents */
-.dashboard-panel.jobs { border-left: tall $accent-blue; border-title-color: $accent-blue; }
-.dashboard-panel.chart { border-left: tall $accent-green; border-title-color: $accent-green; }
-.dashboard-panel.session { border-left: tall $accent-orange; border-title-color: $accent-orange; }
-.dashboard-panel.sources { border-left: tall $accent-red; border-title-color: $accent-red; }
+.dashboard-panel.jobs { border-title-color: $accent-blue; }
+.dashboard-panel.chart { border-title-color: $accent-green; }
+.dashboard-panel.session { border-title-color: $accent-orange; }
+.dashboard-panel.sources { border-title-color: $accent-red; }
 
 /* Activity log at bottom */
 .activity-panel {
     background: $panel;
     border: round $surface-muted;
-    border-left: tall $accent-aqua;
     padding: 0 1;
     height: 1fr;
     min-height: 6;

--- a/src/gengowatcher/main.py
+++ b/src/gengowatcher/main.py
@@ -7,21 +7,33 @@ import sys
 from pathlib import Path
 
 from rich.console import Console
-from rich.text import Text
-from rich.theme import Theme
 
-from .cli import (
-    build_argument_parser,
-    handle_cli_config_commands,
-    should_handle_lightweight_command,
+from .browser_session import (
+    fetch_browser_session_snapshot_sync,
+    fetch_browser_session_token_sync,
 )
+from .cli import build_argument_parser, handle_cli_config_commands, should_handle_lightweight_command
 from .config import AppConfig
 from .logging_setup import APP_THEME
 from .logging_setup import should_enable_stdio_logging as _should_enable_stdio_logging
+from .prom_metrics import start_watcher_metrics_server
 from .runtime import run_application
 
-
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _start_metrics_server_if_enabled(config: AppConfig, watcher, logger):
+    if not config.getboolean("Metrics", "enabled", fallback=False):
+        return None
+
+    host = str(config.get("Metrics", "host", fallback="127.0.0.1") or "127.0.0.1")
+    port = int(config.getint("Metrics", "port", fallback=9091) or 9091)
+    return start_watcher_metrics_server(
+        host=host,
+        port=port,
+        watcher=watcher,
+        logger=logger,
+    )
 
 
 def main() -> None:
@@ -30,183 +42,22 @@ def main() -> None:
     args = parser.parse_args()
     console = Console(theme=APP_THEME)
 
-    # =========================================================================
-    # LIGHTWEIGHT CONFIG COMMANDS - No GengoWatcher initialization required
-    # =========================================================================
-    # Handle config commands BEFORE initializing the heavy GengoWatcher instance.
-    # This allows CLI config operations to work even if another watcher is running.
-
-    if (
-        args.set
-        or args.get
-        or args.list
-        or args.configure
-        or args.sync_session_from_browser
-        or args.check_session_from_browser
-    ):
+    if should_handle_lightweight_command(args):
         try:
             config = AppConfig()
             if handle_cli_config_commands(args, config, console):
                 sys.exit(0)
-        except Exception as e:
-            console.print(f"[error]Configuration error: {e}[/]")
+        except Exception as exc:
+            console.print(f"[error]Configuration error: {exc}[/]")
             sys.exit(1)
 
     run_application(args, console)
 
-    try:
-        config = AppConfig()
-        category_filter = CategoryFilter(config)
-        log.addFilter(category_filter)
-        ui_handler.addFilter(category_filter)
-        if config.get("Logging", "log_main_enabled"):
-            try:
-                log_file = Path(
-                    str(config.get("Paths", "log_file") or "logs/gengowatcher.log")
-                )
-                log_file.parent.mkdir(parents=True, exist_ok=True)
-                # Validate log_max_bytes to prevent handler crash
-                log_max_bytes = config.get("Logging", "log_max_bytes") or 0
-                if log_max_bytes < 1024:  # Minimum 1KB
-                    log_max_bytes = 10485760  # Default 10MB
-                file_handler = RotatingFileHandler(
-                    log_file,
-                    maxBytes=log_max_bytes,
-                    backupCount=config.get("Logging", "log_backup_count") or 5,
-                )
-                file_handler.setFormatter(
-                    logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
-                )
-                log.addHandler(file_handler)
-            except IOError as e:
-                console.print(f"[error]Could not set up file logging: {e}[/]")
-        if args.stdio_logs or config.getboolean(
-            "Logging", "log_stdio_enabled", fallback=False
-        ):
-            stdio_handler = logging.StreamHandler(stream=sys.stderr)
-            stdio_handler.setFormatter(
-                logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
-            )
-            stdio_handler.addFilter(category_filter)
-            log.addHandler(stdio_handler)
-        state = AppState(logger=log)
-        watcher = GengoWatcher(config=config, state=state, logger=log)
-    except Exception as e:
-        if log.handlers:
-            log.critical(f"A critical error occurred during initialization: {e}")
-        else:
-            console.print(
-                f"[error]A critical error occurred during initialization: {e}[/]"
-            )
-        sys.exit(1)
 
-    if args.setup_email:
-        try:
-            from .oauth_setup import run_setup_sync
-
-            success = run_setup_sync(config)
-            sys.exit(0 if success else 1)
-        except ImportError as e:
-            console.print(f"[error]OAuth setup dependencies missing: {e}[/]")
-            console.print("[info]Install with: pip install google-auth-oauthlib[/]")
-            sys.exit(1)
-        except Exception as e:
-            console.print(f"[error]Email setup error: {e}[/]")
-            sys.exit(1)
-
-    if args.setup_website:
-        try:
-            from .website_setup import setup_website_interactive
-
-            success = setup_website_interactive(config)
-            sys.exit(0 if success else 1)
-        except ImportError as e:
-            console.print(f"[error]Website setup dependencies missing: {e}[/]")
-            sys.exit(1)
-        except Exception as e:
-            console.print(f"[error]Website setup error: {e}[/]")
-            sys.exit(1)
-
-    if not watcher.is_config_complete():
-        print("\n⚠️  Configuration is incomplete or contains placeholder values.")
-        print(
-            "The following settings need to be configured for GengoWatcher to work properly:"
-        )
-        watcher.prompt_for_config_values()
-
-    # Start web server if requested
-    web_thread = None
-    if args.web or args.web_only:
-        try:
-            from .web import run_web_server
-
-            def start_web_server():
-                print(f"Starting web server on http://127.0.0.1:{args.web_port}")
-                run_web_server(host="127.0.0.1", port=args.web_port)
-
-            web_thread = threading.Thread(
-                target=start_web_server, daemon=True, name="WebServerThread"
-            )
-            web_thread.start()
-
-            # Give web server time to start
-            import time
-
-            time.sleep(1)
-
-        except ImportError as e:
-            console.print(f"[error]Could not start web server: {e}[/]")
-            console.print("[error]Make sure fastapi and uvicorn are installed[/]")
-            if args.web_only:
-                sys.exit(1)
-
-    # Exit if only web server was requested
-    if args.web_only:
-        try:
-            if web_thread is not None:
-                web_thread.join()
-        except KeyboardInterrupt:
-            console.print("[info]Web server shutting down...[/]")
-        sys.exit(0)
-
-    # Start the Textual TUI
-    stats_manager = StatsManager()
-    app = GengoWatcherApp(
-        watcher=watcher,
-        config=config,
-        state=state,
-        stats=stats_manager,
-    )
-
-    watcher_thread = threading.Thread(
-        target=watcher.run, daemon=True, name="WatcherThread"
-    )
-    watcher_thread.start()
-
-    try:
-        app.run()
-    except Exception as e:
-        log.exception("UI loop crashed")
-    finally:
-        try:
-            stats_manager.end_session()
-        except Exception:
-            log.exception("Failed to persist session stats on shutdown")
-        if not watcher.shutdown_event.is_set():
-            watcher.handle_exit()
-
-    # Print helpful exit message
-    print("\n" + "=" * 60)
-    print("👋 GengoWatcher has shut down.")
-    print("💡 Tip: Run with --configure to change settings later")
-    print("   Example: python -m gengowatcher.main --configure")
-    print("=" * 60)
-
-    try:
-        watcher_thread.join(timeout=2)
-        console.print("[info]GengoWatcher has shut down.[/]")
-    except KeyboardInterrupt:
-        console.print("[info]Shutting down...[/]")
+def run() -> None:
+    """Change to the project root before running the app."""
+    os.chdir(PROJECT_ROOT)
+    main()
 
 
 if __name__ == "__main__":

--- a/src/gengowatcher/runtime.py
+++ b/src/gengowatcher/runtime.py
@@ -51,11 +51,18 @@ def run_application(args: argparse.Namespace, console: Console) -> None:
         )
         watcher.prompt_for_config_values()
 
-    web_thread = _start_web_server_if_requested(args, console)
+    web_thread = _start_web_server_if_requested(
+        args,
+        console,
+        config=config,
+        state=state,
+        logger=log,
+        watcher=watcher,
+    )
     if args.web_only:
         _run_web_only(console, web_thread)
 
-    _run_tui(args, console, log, config, state, watcher)
+    _run_tui(args, console, log, ui_handler, config, state, watcher)
 
 
 def _start_metrics_server_if_enabled(
@@ -108,7 +115,13 @@ def _handle_setup_commands(
 
 
 def _start_web_server_if_requested(
-    args: argparse.Namespace, console: Console
+    args: argparse.Namespace,
+    console: Console,
+    *,
+    config: AppConfig,
+    state: AppState,
+    logger: logging.Logger,
+    watcher: GengoWatcher,
 ) -> threading.Thread | None:
     if not (args.web or args.web_only):
         return None
@@ -118,7 +131,15 @@ def _start_web_server_if_requested(
 
         def start_web_server():
             print(f"Starting web server on http://127.0.0.1:{args.web_port}")
-            run_web_server(host="127.0.0.1", port=args.web_port)
+            run_web_server(
+                host="127.0.0.1",
+                port=args.web_port,
+                config=config,
+                state=state,
+                logger=logger,
+                watcher=watcher,
+                start_watcher_thread=bool(args.web_only),
+            )
 
         web_thread = threading.Thread(
             target=start_web_server, daemon=True, name="WebServerThread"
@@ -147,6 +168,7 @@ def _run_tui(
     args: argparse.Namespace,
     console: Console,
     log: logging.Logger,
+    ui_handler,
     config: AppConfig,
     state: AppState,
     watcher: GengoWatcher,
@@ -157,6 +179,7 @@ def _run_tui(
         config=config,
         state=state,
         stats=stats_manager,
+        ui_log_handler=ui_handler,
     )
 
     watcher_thread = threading.Thread(

--- a/src/gengowatcher/ui_textual.py
+++ b/src/gengowatcher/ui_textual.py
@@ -31,6 +31,7 @@ from textual.widgets import (
 )
 
 from .config import AppConfig
+from .logging_setup import UILoggingHandler
 from .state import AppState
 from .stats import StatsManager
 from .watcher import TIER_UNIT_RATES, GengoWatcher
@@ -715,6 +716,7 @@ class StatusIndicator(Static):
         "stale": ["!", "‼", "!", "·"],
         "error": ["✗", "✖", "✗", "✖"],
     }
+    PULSE_FRAMES: ClassVar[dict[str, list[str]]] = STATE_FRAMES
 
     PULSE_STEPS: ClassVar[dict[str, int]] = {
         "live": 4,
@@ -1612,6 +1614,7 @@ class TelemetryPanel(DashboardQuadrant):
         yield Static("Loading telemetry...", id="telemetry-content")
 
     def on_mount(self) -> None:
+        self.refresh_telemetry()
         self.set_interval(1.0, self.refresh_telemetry)
         self.set_interval(0.2, self._pulse_tick)
 
@@ -2086,19 +2089,25 @@ class GengoWatcherApp(App):
         state: AppState,
         watcher: GengoWatcher,
         stats: StatsManager,
+        ui_log_handler: UILoggingHandler | None = None,
     ):
         super().__init__()
-        self.theme = self.DEFAULT_THEME_NAME
         self.config = config
         self.state = state
         self.watcher = watcher
         self.stats = stats
+        self._ui_log_handler = ui_log_handler
+        self._persist_theme_changes = False
+        configured_theme = self.config.get("UI", "theme_name")
+        self.theme = self._resolve_theme_name(configured_theme)
+        self._persist_theme_changes = True
         self._log_source = cast(
             logging.Logger,
             getattr(self.watcher, "logger", logging.getLogger("gengowatcher")),
         )
         self._textual_log_handler = TextualLogHandler(self)
         self._logging_attached = False
+        self._buffered_logs_replayed = False
 
         # Register callback for when new jobs are detected
         self.watcher.on_job_added_callback = self._on_job_added_from_thread
@@ -2150,6 +2159,11 @@ class GengoWatcherApp(App):
         missing_level: int = logging.DEBUG,
     ) -> None:
         """Attempt to refresh a specific widget and log when it's missing."""
+        widget_name = (
+            widget_class
+            if isinstance(widget_class, str)
+            else getattr(widget_class, "__name__", str(widget_class))
+        )
         try:
             widget = self.query_one(widget_class)
         except NoMatches:
@@ -2180,15 +2194,37 @@ class GengoWatcherApp(App):
             )
 
     def _setup_logging(self):
-        handler = TextualLogHandler(self)
-        logging.getLogger().addHandler(handler)
+        if self._logging_attached:
+            return
+        self._log_source.addHandler(self._textual_log_handler)
+        self._logging_attached = True
+
+    def _replay_buffered_logs(self) -> None:
+        if self._buffered_logs_replayed or self._ui_log_handler is None:
+            return
+
+        queued_logs = list(getattr(self._ui_log_handler, "log_queue", ()))
+        for entry in queued_logs:
+            if not isinstance(entry, Text):
+                continue
+            self._textual_log_handler._write_to_log("#activity-log", entry)
+            self._textual_log_handler._write_to_log("#activity-log-full", entry)
+
+        self._buffered_logs_replayed = True
 
     def on_mount(self) -> None:
         """Initialize the jobs table with columns when the app mounts."""
         self._setup_logging()
+        self._replay_buffered_logs()
         self._setup_jobs_table()
         self._refresh_dashboard_panels()
         self.set_interval(1.0, self._refresh_dashboard_panels)
+
+    def on_unmount(self) -> None:
+        if self._logging_attached:
+            self._log_source.removeHandler(self._textual_log_handler)
+            self._logging_attached = False
+        self.watcher.on_job_added_callback = None
 
     def _dashboard_refresh_targets(self) -> list[tuple[type, str]]:
         """Return the required refresh targets for mounted dashboard widgets."""
@@ -2207,6 +2243,22 @@ class GengoWatcherApp(App):
                 method_name,
                 missing_level=logging.WARNING,
             )
+
+    def watch_theme(self, theme: str) -> None:
+        if not theme or not getattr(self, "_persist_theme_changes", False):
+            return
+        self.config.set("UI", "theme_name", theme)
+        self.config.save_config()
+
+    def _resolve_theme_name(self, configured_theme: object) -> str:
+        theme_name = str(configured_theme or "").strip()
+        if theme_name in self.available_themes:
+            return theme_name
+        if self.DEFAULT_THEME_NAME in self.available_themes:
+            return self.DEFAULT_THEME_NAME
+        if self.available_themes:
+            return next(iter(self.available_themes))
+        return self.DEFAULT_THEME_NAME
 
     def _setup_jobs_table(self) -> None:
         """Set up the jobs DataTable with columns."""

--- a/src/gengowatcher/ui_textual.py
+++ b/src/gengowatcher/ui_textual.py
@@ -1196,17 +1196,10 @@ class HourlyActivity(DashboardQuadrant):
                     peak_period = f"{peak_period_start:02d}-{peak_period_end:02d}"
                     values = [hourly_counts.get(hour, 0.0) for hour in range(24)]
                     chart_values = _aggregate_series(values, bin_size=2)
-                    chart = _render_plotext_bar_chart(
+                    chart = _render_chart_with_axes(
                         chart_values,
-                        width=30,
-                        height=8,
-                        x_left="00:00",
-                        x_mid="12:00",
-                        x_right="23:59",
-                    ) or _render_chart_with_axes(
-                        chart_values,
-                        width=len(chart_values),
-                        height=4,
+                        width=min(30, max(12, len(chart_values))),
+                        height=6,
                         x_left="00:00",
                         x_right="23:59",
                     )

--- a/src/gengowatcher/watcher.py
+++ b/src/gengowatcher/watcher.py
@@ -18,6 +18,7 @@ import webbrowser
 from typing import Callable, Optional
 from collections import deque
 from pathlib import Path
+from urllib.parse import urlparse
 
 import feedparser
 import websockets
@@ -771,7 +772,10 @@ class GengoWatcher:
 
     def _is_gengo_rss_feed(self) -> bool:
         feed_url = str(self.config.get("Watcher", "feed_url") or "")
-        return "gengo.com" in feed_url.lower()
+        host = urlparse(feed_url).hostname
+        if not host:
+            return False
+        return host == "gengo.com" or host.endswith(".gengo.com")
 
     def _get_effective_rss_wait_range_seconds(self) -> tuple[float, float]:
         if self._is_gengo_rss_feed():

--- a/src/gengowatcher/watcher.py
+++ b/src/gengowatcher/watcher.py
@@ -23,7 +23,13 @@ import feedparser
 import websockets
 from websockets.exceptions import ConnectionClosed, InvalidHandshake, InvalidStatusCode
 
-from .browser_session import fetch_browser_session_token_sync
+from .browser_session import (
+    build_browser_aligned_websocket_headers,
+    build_websocket_auth_payload,
+    fetch_browser_session_snapshot_sync,
+    refresh_browser_page_activity_sync,
+)
+from .browser_detector import get_preferred_browser_user_agent
 from .config import AppConfig
 from .job_acceptance import JobAcceptanceEngine
 from .job_cancellation_manager import JobCancellationManager
@@ -123,6 +129,7 @@ class GengoWatcher:
         self.websocket_ping_latency_ms = None  # float milliseconds
         self.websocket_next_ping_ts = None  # float epoch seconds
         self.websocket_last_message_ts = None  # float epoch seconds
+        self.websocket_connected_at_ts = None  # float epoch seconds
         self.websocket_last_close_code = None
         self.websocket_last_close_reason = None
         self.websocket_reconnect_count = 0
@@ -149,6 +156,7 @@ class GengoWatcher:
         self._browser_session_last_sync_ts = None
         self._browser_session_last_sync_state = "idle"
         self._browser_session_last_sync_detail = "never synced"
+        self._next_quiet_socket_sync_ts = None
         self._health_alert_states = {}
         # Thread references for health monitoring
         self._monitor_threads = {}  # name -> threading.Thread
@@ -197,8 +205,12 @@ class GengoWatcher:
     @staticmethod
     def _mask_secret(value) -> str:
         text = str(value or "").strip()
+        if not text:
+            return ""
+        if len(text) <= 4:
+            return "*" * len(text)
         if len(text) <= 8:
-            return text
+            return f"{text[0]}{'*' * (len(text) - 2)}{text[-1]}"
         return f"{text[:4]}...{text[-4:]}"
 
     def _warn_if_browser_session_mismatch(self) -> None:
@@ -209,7 +221,7 @@ class GengoWatcher:
             return
 
         try:
-            browser_token = fetch_browser_session_token_sync(str(debug_url))
+            snapshot = fetch_browser_session_snapshot_sync(str(debug_url))
         except Exception as exc:
             self.logger.debug(
                 "Browser session check skipped for %s: %s",
@@ -218,12 +230,14 @@ class GengoWatcher:
             )
             return
 
+        browser_token = snapshot.session_token
         if browser_token == configured_token:
             return
 
         self.logger.warning(
             "WebSocket.user_session differs from the live browser session at %s "
-            "(config=%s browser=%s). Realtime detections may fall back to RSS until you sync the token.",
+            "(config=%s browser=%s). Realtime detections may fall back to RSS until"
+            " you sync the token.",
             debug_url,
             self._mask_secret(configured_token),
             self._mask_secret(browser_token),
@@ -264,6 +278,33 @@ class GengoWatcher:
             "WebSocket", "session_sync_interval_sec", fallback=14400
         )
 
+    def _has_cached_websocket_credentials(self) -> bool:
+        session_token = str(
+            self.config.get("WebSocket", "user_session") or ""
+        ).strip()
+        return bool(session_token and session_token not in PLACEHOLDER_CONFIG_VALUES)
+
+    def _get_session_quiet_probe_seconds(self) -> int:
+        return self.config.getint(
+            "WebSocket", "session_quiet_probe_sec", fallback=90
+        )
+
+    def _get_session_quiet_stale_seconds(self) -> int:
+        configured = self.config.getint(
+            "WebSocket", "session_quiet_stale_after_sec", fallback=0
+        )
+        if configured and configured > 0:
+            return configured
+        return max(self._get_session_quiet_probe_seconds() * 2, 300)
+
+    def _get_websocket_quiet_age(self, current_time: float) -> float | None:
+        if self.websocket_connected_at_ts is None:
+            return None
+        last_activity_ts = (
+            self.websocket_last_message_ts or self.websocket_connected_at_ts
+        )
+        return max(0.0, current_time - last_activity_ts)
+
     @staticmethod
     def _timestamp_or_none(value):
         if value is None:
@@ -283,6 +324,7 @@ class GengoWatcher:
         """Return actionable subsystem health instead of coarse absolute state."""
         current_time = now if now is not None else time.time()
         check_interval = float(self.config.get("Watcher", "check_interval") or 45)
+        browser_debug_url = self.config.get("WebSocket", "browser_debug_url") or ""
         ws_enabled = self.config.getboolean(
             "WebSocket", "enable_websocket", fallback=True
         )
@@ -305,6 +347,7 @@ class GengoWatcher:
         ws_detail = "off"
         last_pong_age = None
         last_message_age = None
+        quiet_age = self._get_websocket_quiet_age(current_time)
         if self.websocket_last_pong_ts is not None:
             last_pong_age = max(0.0, current_time - self.websocket_last_pong_ts)
         if self.websocket_last_message_ts is not None:
@@ -458,7 +501,6 @@ class GengoWatcher:
         session_state = "disabled"
         session_detail = "off"
         session_age = None
-        browser_debug_url = self.config.get("WebSocket", "browser_debug_url") or ""
         if browser_debug_url:
             if self._browser_session_last_sync_ts is not None:
                 session_age = max(
@@ -489,6 +531,7 @@ class GengoWatcher:
                 "status": self.websocket_status,
                 "last_pong_age_sec": last_pong_age,
                 "last_message_age_sec": last_message_age,
+                "quiet_age_sec": quiet_age,
                 "ping_latency_ms": self.websocket_ping_latency_ms,
                 "reconnect_count": self.websocket_reconnect_count,
                 "last_close_code": self.websocket_last_close_code,
@@ -552,10 +595,24 @@ class GengoWatcher:
             self._health_alert_states[key] = state
             if state not in {"stale", "error"} or previous == state:
                 continue
+            sound_file = None
+            play_sound = True
+            if key == "websocket" and state == "stale":
+                sound_file = (
+                    self.config.get(
+                        "Paths",
+                        "websocket_stale_sound_file",
+                        fallback="",
+                    )
+                    or None
+                )
+                if detail.startswith("quiet "):
+                    play_sound = False
             self.show_notification(
                 message=f"{key.title()} is {state}: {detail}",
                 title="GengoWatcher Telemetry Alert",
-                play_sound=True,
+                play_sound=play_sound,
+                sound_file=sound_file,
             )
 
     def _sync_session_from_browser(
@@ -570,7 +627,7 @@ class GengoWatcher:
             return False
 
         try:
-            browser_token = fetch_browser_session_token_sync(str(debug_url))
+            snapshot = fetch_browser_session_snapshot_sync(str(debug_url))
         except Exception as exc:
             self._browser_session_last_sync_ts = time.time()
             self._browser_session_last_sync_state = "error"
@@ -580,11 +637,25 @@ class GengoWatcher:
                 debug_url,
                 exc,
             )
+            if self._has_cached_websocket_credentials():
+                self.logger.warning(
+                    "Browser session sync failed for %s, but cached WebSocket"
+                    " credentials are present. Continuing with the last known"
+                    " session instead of stopping realtime monitoring.",
+                    debug_url,
+                )
+                self._websocket_sync_failed = False
+                self._websocket_sync_failure_reason = None
+                return False
             if alert_on_failure:
+                sound_file = self.config.get(
+                    "Paths", "browser_session_sync_failed_sound_file"
+                )
                 self.show_notification(
                     message=f"Browser session sync failed: {exc}",
                     title="GengoWatcher Session Sync Failed",
                     play_sound=True,
+                    sound_file=sound_file or None,
                 )
             if fail_hard:
                 self._websocket_sync_failed = True
@@ -593,24 +664,183 @@ class GengoWatcher:
             return False
 
         current_token = self.config.get("WebSocket", "user_session")
+        current_browser_user_agent = self.config.get("Network", "browser_user_agent")
+        current_accept_language = self.config.get(
+            "Network", "browser_accept_language"
+        )
+        browser_token = snapshot.session_token
+        browser_user_agent = str(snapshot.user_agent or "").strip()
+        browser_accept_language = str(snapshot.accept_language or "").strip()
         self._browser_session_last_sync_ts = time.time()
         self._browser_session_last_sync_state = "healthy"
-        if browser_token == current_token:
-            self._browser_session_last_sync_detail = "unchanged"
-            return False
+        changed_fields = []
+        if browser_token != current_token:
+            self.config.set("WebSocket", "user_session", browser_token)
+            changed_fields.append("user_session")
+        if (
+            browser_user_agent
+            and browser_user_agent != str(current_browser_user_agent or "").strip()
+        ):
+            self.config.set("Network", "browser_user_agent", browser_user_agent)
+            changed_fields.append("browser_user_agent")
+        if (
+            browser_accept_language
+            and browser_accept_language != str(current_accept_language or "").strip()
+        ):
+            self.config.set(
+                "Network", "browser_accept_language", browser_accept_language
+            )
+            changed_fields.append("browser_accept_language")
+        if str(debug_url) != str(self.config.get("WebSocket", "browser_debug_url") or ""):
+            self.config.set("WebSocket", "browser_debug_url", str(debug_url))
+            changed_fields.append("browser_debug_url")
 
-        self.config.set("WebSocket", "user_session", browser_token)
-        self.config.set("WebSocket", "browser_debug_url", str(debug_url))
-        self.config.save_config()
-        self._browser_session_last_sync_detail = "updated"
+        if changed_fields:
+            self.config.save_config()
+            self._browser_session_last_sync_detail = (
+                f"updated {', '.join(changed_fields)}"
+            )
+        else:
+            self._browser_session_last_sync_detail = "unchanged"
         self.logger.info(
-            "Updated WebSocket.user_session from live browser session at %s "
-            "(old=%s new=%s)",
+            "Updated WebSocket session settings from live browser session at %s "
+            "(session=%s)",
             debug_url,
-            self._mask_secret(current_token),
             self._mask_secret(browser_token),
         )
-        return True
+        return bool(changed_fields)
+
+    def _pick_quiet_socket_sync_delay_seconds(self) -> float:
+        min_delay = float(
+            self.config.get("WebSocket", "browser_activity_min_sec", fallback=300)
+            or 300
+        )
+        max_delay = float(
+            self.config.get("WebSocket", "browser_activity_max_sec", fallback=3600)
+            or 3600
+        )
+        if max_delay < min_delay:
+            min_delay, max_delay = max_delay, min_delay
+        return random.uniform(min_delay, max_delay)
+
+    def _sync_browser_session_for_quiet_socket(
+        self,
+        *,
+        current_time: float | None = None,
+        fail_hard: bool = False,
+        alert_on_failure: bool = False,
+    ) -> bool:
+        """Refresh the browser session when a quiet websocket needs a recheck."""
+        debug_url = self.config.get("WebSocket", "browser_debug_url")
+        if not debug_url or self.websocket_status != "Live":
+            return False
+
+        now = current_time if current_time is not None else time.time()
+        quiet_age = self._get_websocket_quiet_age(now)
+        quiet_probe_after = self._get_session_quiet_probe_seconds()
+        if quiet_age is None or quiet_age < quiet_probe_after:
+            return False
+
+        next_sync_ts = self._next_quiet_socket_sync_ts
+        if next_sync_ts is not None and now < next_sync_ts:
+            return False
+        if self._browser_session_last_sync_ts is not None:
+            sync_age = max(0.0, now - self._browser_session_last_sync_ts)
+            if sync_age < quiet_probe_after:
+                return False
+
+        self.logger.warning(
+            "WebSocket: No application messages for %.1fs while live; syncing browser"
+            " session from %s before continuing.",
+            quiet_age,
+            debug_url,
+        )
+
+        changed = self._sync_session_from_browser(
+            fail_hard=fail_hard,
+            alert_on_failure=alert_on_failure,
+        )
+        if changed:
+            self._next_quiet_socket_sync_ts = None
+            return True
+
+        self._next_quiet_socket_sync_ts = (
+            now + self._pick_quiet_socket_sync_delay_seconds()
+        )
+        return False
+
+    def _is_gengo_rss_feed(self) -> bool:
+        feed_url = str(self.config.get("Watcher", "feed_url") or "")
+        return "gengo.com" in feed_url.lower()
+
+    def _get_effective_rss_wait_range_seconds(self) -> tuple[float, float]:
+        if self._is_gengo_rss_feed():
+            min_delay = float(
+                self.config.get("Watcher", "gengo_rss_interval_min_sec", fallback=31)
+                or 31
+            )
+            max_delay = float(
+                self.config.get("Watcher", "gengo_rss_interval_max_sec", fallback=60)
+                or 60
+            )
+            if max_delay < min_delay:
+                min_delay, max_delay = max_delay, min_delay
+            return min_delay, max_delay
+
+        check_interval = float(self.config.get("Watcher", "check_interval") or 45)
+        return check_interval, check_interval
+
+    def _get_effective_rss_check_interval(self) -> float:
+        if self._is_gengo_rss_feed():
+            _min_delay, max_delay = self._get_effective_rss_wait_range_seconds()
+            check_interval = float(self.config.get("Watcher", "check_interval") or 45)
+            return max(check_interval, max_delay)
+        return float(self.config.get("Watcher", "check_interval") or 45)
+
+    def _pick_next_rss_wait_seconds(self) -> float:
+        min_delay, max_delay = self._get_effective_rss_wait_range_seconds()
+        if min_delay == max_delay:
+            return min_delay
+        return random.uniform(min_delay, max_delay)
+
+    def _pick_planned_websocket_reconnect_delay_seconds(self) -> float:
+        min_delay = float(
+            self.config.get("WebSocket", "planned_reconnect_min_sec", fallback=300)
+            or 300
+        )
+        max_delay = float(
+            self.config.get("WebSocket", "planned_reconnect_max_sec", fallback=3600)
+            or 3600
+        )
+        if max_delay < min_delay:
+            min_delay, max_delay = max_delay, min_delay
+        return random.uniform(min_delay, max_delay)
+
+    def _pick_browser_activity_delay_seconds(self) -> float:
+        min_delay = float(
+            self.config.get("WebSocket", "browser_activity_min_sec", fallback=300)
+            or 300
+        )
+        max_delay = float(
+            self.config.get("WebSocket", "browser_activity_max_sec", fallback=3600)
+            or 3600
+        )
+        if max_delay < min_delay:
+            min_delay, max_delay = max_delay, min_delay
+        return random.uniform(min_delay, max_delay)
+
+    def _perform_browser_activity(self) -> str | None:
+        debug_url = self.config.get("WebSocket", "browser_debug_url")
+        if not debug_url:
+            return None
+
+        previous_action = getattr(self, "_last_browser_activity_action", None)
+        action = refresh_browser_page_activity_sync(
+            str(debug_url),
+            previous_action=previous_action,
+        )
+        self._last_browser_activity_action = action
+        return action
 
     def get_monitor_status(self) -> dict:
         """
@@ -911,50 +1141,11 @@ class GengoWatcher:
                         metadata=job_data,
                     )
                     self.state.save_state()
-                    self._notify_job_added(job_data, True, job_id)
-                    return
-                except Exception as e:
-                    self.logger.error(
-                        "Failed to submit job %s to browser worker: %s; falling back to"
-                        " standard acceptance path",
-                        job_id,
-                        e,
-                    )
-            self.logger.info(
-                "Continuing with standard acceptance flow for job %s after browser worker"
-                " handoff failed",
-                job_id,
-            )
-
-        eligible_for_auto_accept = self.job_acceptance_engine.is_job_eligible(job_data)
-
-        if self.browser_worker_enabled and eligible_for_auto_accept:
-            self.logger.info(
-                "Routing job %s to browser worker via local client", job_id
-            )
-            if not self.browser_worker_client:
-                self.logger.error(
-                    "Browser worker is enabled for job %s but the local client is unavailable;"
-                    " falling back to standard acceptance path",
-                    job_id,
-                )
-            else:
-                try:
-                    self.browser_worker_client.submit_job(
-                        url,
-                        source,
-                        metadata=job_data,
-                    )
-                    self.state.save_state()
-                    if self.on_job_added_callback and job_added:
+                    if self.on_job_added_callback:
                         try:
                             self.on_job_added_callback(job_data)
                         except Exception as e:
                             self.logger.debug(f"Error in job added callback: {e}")
-                    elif self.on_job_added_callback and not job_added:
-                        self.logger.debug(
-                            f"Skipping job added callback for job {job_id} because it was not stored in state"
-                        )
                     return
                 except Exception as e:
                     self.logger.error(
@@ -1001,8 +1192,11 @@ class GengoWatcher:
 
         self.state.save_state()
 
-        # Notify integrations/UI that a new job was added
-        self._notify_job_added(job_data, True, job_id)
+        if self.on_job_added_callback:
+            try:
+                self.on_job_added_callback(job_data)
+            except Exception as e:
+                self.logger.debug(f"Error in job added callback: {e}")
 
     def _normalize_meta(self, meta) -> dict:
         if meta is None or not hasattr(meta, "get"):
@@ -1395,12 +1589,6 @@ class GengoWatcher:
                 if session_token and len(session_token) > 8
                 else "NOT_SET"
             )
-            masked_user_key = (
-                f"{user_key[:4]}...{user_key[-4:]}"
-                if user_key and len(user_key) > 8
-                else "NOT_SET"
-            )
-
             additional_headers = build_browser_aligned_websocket_headers(
                 session_token=session_token,
                 user_agent=user_agent,
@@ -1426,7 +1614,7 @@ class GengoWatcher:
                     headers (dict | None): Optional additional HTTP headers to include in the WebSocket handshake; pass None to omit custom headers.
 
                 Detailed behaviour:
-                    - Connects to the configured WebSocket URL and sends an authentication payload containing the configured `user_id`, the stored session token, and the browser-aligned `user_key` when available.
+                    - Connects to the configured WebSocket URL and sends an authentication payload containing the configured `user_id` and stored session token.
                     - Starts a heartbeat task that measures ping/pong latency and updates connection timing/state attributes.
                     - Starts a test-monitor task that responds to manual UI test commands (e.g. ping, notify).
                     - Listens for incoming messages and invokes the watcher's message handling for recognised events (notably `available_collection` events, which are forwarded to `_process_new_job`).
@@ -1461,13 +1649,10 @@ class GengoWatcher:
                     auth_payload = build_websocket_auth_payload(
                         user_id=user_id,
                         session_token=session_token,
-                        user_key=user_key,
                     )
-                    # Log auth attempt safely
                     self.logger.debug(
-                        "WebSocket: Sending auth payload for user_id=%s (user_key=%s)",
+                        "WebSocket: Sending auth payload for user_id=%s",
                         user_id,
-                        masked_user_key,
                     )
 
                     auth_json = json.dumps(auth_payload)
@@ -2104,6 +2289,9 @@ class GengoWatcher:
 
     def list_config_values(self):
         config_dict = self.config.list_all()
+        if not isinstance(config_dict, dict):
+            fallback_config = getattr(self.config, "config", None)
+            config_dict = fallback_config if isinstance(fallback_config, dict) else {}
         self.logger.debug(f"Listing all config values: {config_dict}")
         return config_dict
 

--- a/src/gengowatcher/web.py
+++ b/src/gengowatcher/web.py
@@ -199,38 +199,50 @@ class StoredFileUploadResponse(BaseModel):
 class WebAPI:
     """Web API wrapper for GengoWatcher that maintains thread safety."""
 
-    def __init__(self, config: AppConfig, state: AppState, logger: logging.Logger):
+    def __init__(
+        self,
+        config: AppConfig,
+        state: AppState,
+        logger: logging.Logger,
+        *,
+        watcher: GengoWatcher | None = None,
+        start_watcher_thread: bool = True,
+    ):
         """Initialize the WebAPI instance.
 
-        Creates a separate GengoWatcher instance for the web API to avoid conflicts
-        with the TUI. Sets up thread safety mechanisms and starts the watcher thread.
+        Uses a shared watcher when provided, otherwise creates its own watcher.
+        This allows the web API to run alongside the TUI without starting a
+        duplicate RSS/WebSocket monitor loop.
 
         Args:
             config: Application configuration object.
             state: Application state object for data persistence.
             logger: Logger instance for recording events.
+            watcher: Optional shared watcher instance owned by the runtime.
+            start_watcher_thread: Whether this WebAPI instance should start and
+                manage the watcher thread lifecycle.
         """
         self.config = config
         self.state = state
         self.logger = logger
-
-        # Create a separate watcher instance for web API
-        # This allows web UI to run alongside TUI without conflicts
-        self.watcher = GengoWatcher(config, state, logger)
+        self._manage_watcher_lifecycle = start_watcher_thread
+        self.watcher = watcher if watcher is not None else GengoWatcher(config, state, logger)
 
         # Thread safety for shared state access
         self._status_lock = threading.RLock()  # Reentrant lock for better safety
         self._active_connections: List[WebSocket] = []
         self._connections_lock = threading.RLock()
         self._jobs_lock = threading.RLock()
+        self.watcher_thread: threading.Thread | None = None
 
-        # Start the watcher in a separate thread
-        self.watcher_thread = threading.Thread(
-            target=self.watcher.run, daemon=True, name="WebWatcherThread"
-        )
-        self.watcher_thread.start()
-
-        self.logger.info("WebAPI initialized and watcher thread started")
+        if start_watcher_thread:
+            self.watcher_thread = threading.Thread(
+                target=self.watcher.run, daemon=True, name="WebWatcherThread"
+            )
+            self.watcher_thread.start()
+            self.logger.info("WebAPI initialized and watcher thread started")
+        else:
+            self.logger.info("WebAPI initialized using shared watcher instance")
 
     def get_status(self) -> WatcherStatus:
         """Get current watcher status."""
@@ -247,9 +259,16 @@ class WebAPI:
             health_snapshot = {}
             health_getter = getattr(self.watcher, "get_health_snapshot", None)
             if callable(health_getter):
-                candidate = health_getter()
-                if isinstance(candidate, dict):
-                    health_snapshot = candidate
+                try:
+                    candidate = health_getter()
+                except Exception as exc:
+                    self.logger.warning(
+                        "Failed to collect watcher health snapshot for web status: %s",
+                        exc,
+                    )
+                else:
+                    if isinstance(candidate, dict):
+                        health_snapshot = candidate
 
             return WatcherStatus(
                 is_running=not self.watcher.shutdown_event.is_set(),
@@ -302,11 +321,13 @@ class WebAPI:
         # Accept only a single filename component (no user-influenced subpaths).
         candidate_path = Path(path)
         candidate_name = candidate_path.name
-        if (
-            candidate_name in {"", ".", ".."}
-            or candidate_path != Path(candidate_name)
-        ):
+        if candidate_name in {"", ".", ".."}:
             raise ValueError("Invalid stored filename")
+        if candidate_path != Path(candidate_name):
+            try:
+                candidate_path.resolve(strict=False).parent.relative_to(storage_dir)
+            except ValueError as exc:
+                raise ValueError("Invalid stored filename") from exc
 
         try:
             resolved = (storage_dir / candidate_name).resolve(strict=False)
@@ -331,7 +352,7 @@ class WebAPI:
             return False
         if self._sanitize_filename(name) != name:
             return False
-        return re.fullmatch(r"[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)?", name) is not None
+        return re.fullmatch(r"[A-Za-z0-9_() .-]+", name) is not None
 
     def _build_file_entry(
         self,
@@ -413,10 +434,6 @@ class WebAPI:
         word_count: int | None = None,
         value: float | None = None,
     ) -> StoredFileEntry:
-        if job_id is not None:
-            job_id = str(job_id).strip()
-            if not re.fullmatch(r"[A-Za-z0-9_-]{1,64}", job_id):
-                raise ValueError("Invalid job id")
         if job_id is not None:
             job_id = str(job_id).strip()
             if not re.fullmatch(r"[A-Za-z0-9_-]{1,64}", job_id):
@@ -884,11 +901,13 @@ class WebAPI:
     def shutdown(self):
         """Shutdown the web API and watcher."""
         self.logger.info("Shutting down WebAPI")
-        self.watcher.handle_exit()
+        if self._manage_watcher_lifecycle:
+            self.watcher.handle_exit()
 
 
 # Global API instance
 api_instance: Optional[WebAPI] = None
+shared_runtime_context: Optional[Dict[str, Any]] = None
 
 
 PROM_API_INITIALIZED = Gauge(
@@ -906,27 +925,40 @@ ensure_watcher_metrics_registered(
 async def lifespan(app: FastAPI):
     """FastAPI lifespan context manager."""
     global api_instance
+    global shared_runtime_context
 
     # Startup
     logger = logging.getLogger("gengowatcher.web")
     try:
-        # Check if config exists, create it if needed
-        from pathlib import Path
-
-        config_path = Path(AppConfig.CONFIG_FILE)
-        if not config_path.exists():
-            logger.info("Creating default %s for web API", AppConfig.CONFIG_FILE)
-            config_path.write_text(
-                AppConfig._dump_toml(AppConfig.DEFAULT_CONFIG),
-                encoding="utf-8",
+        runtime_context = shared_runtime_context
+        shared_watcher = None
+        start_watcher_thread = True
+        if runtime_context:
+            config = runtime_context["config"]
+            state = runtime_context["state"]
+            logger = runtime_context.get("logger") or logger
+            shared_watcher = runtime_context.get("watcher")
+            start_watcher_thread = bool(
+                runtime_context.get("start_watcher_thread", True)
             )
-            logger.info(
-                "Default config created. Please review %s before using the web API.",
-                AppConfig.CONFIG_FILE,
-            )
+        else:
+            # Check if config exists, create it if needed
+            from pathlib import Path
 
-        config = AppConfig()
-        state = AppState(logger=logger)
+            config_path = Path(AppConfig.CONFIG_FILE)
+            if not config_path.exists():
+                logger.info("Creating default %s for web API", AppConfig.CONFIG_FILE)
+                config_path.write_text(
+                    AppConfig._dump_toml(AppConfig.DEFAULT_CONFIG),
+                    encoding="utf-8",
+                )
+                logger.info(
+                    "Default config created. Please review %s before using the web API.",
+                    AppConfig.CONFIG_FILE,
+                )
+
+            config = AppConfig()
+            state = AppState(logger=logger)
 
         # Initialize authenticator with config token
         api_token = config.get("WebServer", "auth_token")
@@ -946,7 +978,13 @@ async def lifespan(app: FastAPI):
         global authenticator
         authenticator = APIAuthenticator(api_token)
 
-        api_instance = WebAPI(config, state, logger)
+        api_instance = WebAPI(
+            config,
+            state,
+            logger,
+            watcher=shared_watcher,
+            start_watcher_thread=start_watcher_thread,
+        )
         logger.info("WebAPI started successfully")
     except Exception as e:
         logger.exception(f"Failed to start WebAPI: {e}")
@@ -957,6 +995,7 @@ async def lifespan(app: FastAPI):
     # Shutdown
     if api_instance:
         api_instance.shutdown()
+    shared_runtime_context = None
 
 
 # Create FastAPI app
@@ -1401,11 +1440,30 @@ async def serve_react_app(path: str):
         raise HTTPException(status_code=404, detail="React app not built yet")
 
 
-def run_web_server(host: str = "127.0.0.1", port: int = 8000):
+def run_web_server(
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    *,
+    config: AppConfig | None = None,
+    state: AppState | None = None,
+    logger: logging.Logger | None = None,
+    watcher: GengoWatcher | None = None,
+    start_watcher_thread: bool = True,
+):
     """Run the web server."""
-    uvicorn.run(
-        "gengowatcher.web:app", host=host, port=port, reload=False, log_level="info"
-    )
+    global shared_runtime_context
+    if config is not None and state is not None:
+        shared_runtime_context = {
+            "config": config,
+            "state": state,
+            "logger": logger,
+            "watcher": watcher,
+            "start_watcher_thread": start_watcher_thread,
+        }
+    else:
+        shared_runtime_context = None
+
+    uvicorn.run(app, host=host, port=port, reload=False, log_level="info")
 
 
 if __name__ == "__main__":

--- a/tests/test_browser_session.py
+++ b/tests/test_browser_session.py
@@ -144,22 +144,6 @@ async def test_fetch_browser_session_token_reads_cookie_from_cdp():
             ]
         },
     }
-    runtime_response = {
-        "id": 2,
-        "result": {
-            "result": {
-                "type": "object",
-                "value": {
-                    "userKey": "browser-user-key",
-                    "userAgent": "Helium Browser",
-                    "acceptLanguage": "en-GB,en-US;q=0.9",
-                    "origin": "https://gengo.com",
-                    "url": "https://gengo.com/t/jobs/status/available/realtime",
-                    "title": "Gengo",
-                },
-            }
-        },
-    }
 
     with (
         patch(
@@ -168,7 +152,7 @@ async def test_fetch_browser_session_token_reads_cookie_from_cdp():
         ),
         patch(
             "gengowatcher.browser_session.websockets.connect",
-            return_value=_MockCDPWebSocket(cdp_response),
+            return_value=_MockCDPWebSocket([cdp_response]),
         ),
     ):
         token = await fetch_browser_session_token("http://127.0.0.1:9222")
@@ -227,6 +211,47 @@ async def test_fetch_browser_session_snapshot_reads_cookie_and_local_storage():
     assert snapshot.user_agent == "Helium Browser"
     assert snapshot.accept_language == "en-GB,en-US;q=0.9"
     assert snapshot.target_title == "Realtime Jobs"
+
+
+@pytest.mark.asyncio
+async def test_fetch_browser_session_snapshot_keeps_cookie_when_runtime_eval_fails():
+    targets = [
+        {
+            "type": "page",
+            "url": "https://gengo.com/t/jobs/status/available/realtime",
+            "webSocketDebuggerUrl": "ws://gengo-target",
+        }
+    ]
+    cookie_response = {
+        "id": 1,
+        "result": {
+            "cookies": [
+                {"name": "myG_myGSession_", "value": "fresh-token"},
+            ]
+        },
+    }
+
+    with (
+        patch(
+            "gengowatcher.browser_session.urllib.request.urlopen",
+            return_value=_MockUrlResponse(targets),
+        ),
+        patch(
+            "gengowatcher.browser_session.websockets.connect",
+            return_value=_MockCDPWebSocket([cookie_response]),
+        ),
+        patch(
+            "gengowatcher.browser_session._evaluate_expression",
+            side_effect=BrowserSessionError("runtime timed out"),
+        ),
+    ):
+        snapshot = await fetch_browser_session_snapshot("http://127.0.0.1:9222")
+
+    assert snapshot.session_token == "fresh-token"
+    assert snapshot.user_key == ""
+    assert snapshot.user_agent == ""
+    assert snapshot.accept_language == ""
+    assert snapshot.target_url == "https://gengo.com/t/jobs/status/available/realtime"
 
 
 @pytest.mark.asyncio
@@ -351,14 +376,17 @@ def test_build_browser_aligned_websocket_headers_uses_browser_profile():
     )
 
     assert headers == {
-        "Cookie": "myG_myGSession_=fresh-token; myG_rdsessID=fresh-token",
         "Origin": "https://gengo.com",
+        "Cookie": "myG_myGSession_=fresh-token; myG_rdsessID=fresh-token",
+        "Pragma": "no-cache",
+        "Cache-Control": "no-cache",
         "User-Agent": "Helium Browser",
         "Accept-Language": "en-GB,en-US;q=0.9",
+        "Accept-Encoding": "gzip, deflate, br, zstd",
     }
 
 
-def test_build_websocket_auth_payload_includes_user_key_when_present():
+def test_build_websocket_auth_payload_uses_session_only():
     payload = build_websocket_auth_payload(
         user_id=12345,
         session_token="fresh-token",
@@ -368,7 +396,6 @@ def test_build_websocket_auth_payload_includes_user_key_when_present():
     assert payload == {
         "user_id": 12345,
         "user_session": "fresh-token",
-        "user_key": "browser-user-key",
     }
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,3 +22,15 @@ def test_setup_aliases_map_to_email_and_website_flags():
     assert email_args.setup_email is True
     assert website_args.setup_website is True
     assert website_site_args.setup_website is True
+
+
+def test_browser_session_flags_map_to_lightweight_commands():
+    parser = build_argument_parser()
+
+    sync_args = parser.parse_args(["--sync-session-from-browser"])
+    check_args = parser.parse_args(["--check-session-from-browser"])
+
+    assert sync_args.sync_session_from_browser is True
+    assert check_args.check_session_from_browser is True
+    assert should_handle_lightweight_command(sync_args) is True
+    assert should_handle_lightweight_command(check_args) is True

--- a/tests/test_ui_textual_components.py
+++ b/tests/test_ui_textual_components.py
@@ -449,6 +449,44 @@ class TestStatusRow:
             assert "ping_latency_ms" in rendered
             assert "RSS" in rendered
 
+    @pytest.mark.asyncio
+    async def test_telemetry_panel_pulse_tick_animates_status_icons(self, mock_watcher):
+        """Telemetry panel should re-render animated icons as the pulse timer advances."""
+        from textual.app import App
+        from textual.widgets import Static
+
+        mock_watcher.get_health_snapshot.return_value = {
+            "websocket": {
+                "state": "stale",
+                "detail": "pong 52s",
+                "last_pong_age_sec": 52,
+            },
+            "rss": {
+                "state": "working",
+                "detail": "processing",
+                "last_success_age_sec": 4,
+            },
+        }
+
+        class TestApp(App):
+            def compose(self):
+                yield TelemetryPanel(watcher=mock_watcher)
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            panel = app.query_one(TelemetryPanel)
+            panel.refresh_telemetry()
+            await pilot.pause(0.1)
+            content = panel.query_one("#telemetry-content", Static)
+            first_render = str(content.render())
+
+            panel._pulse_tick()
+            panel._pulse_tick()
+            await pilot.pause(0.1)
+            second_render = str(content.render())
+
+            assert first_render != second_render
+
     def test_status_indicator_uses_distinct_pulse_cadence_by_state(self):
         """Critical states should pulse faster than non-critical ones."""
         indicator = StatusIndicator("x", "Test")

--- a/tests/test_ui_textual_comprehensive.py
+++ b/tests/test_ui_textual_comprehensive.py
@@ -9,6 +9,7 @@ import datetime
 import logging
 import re
 
+from gengowatcher.logging_setup import UILoggingHandler
 from gengowatcher.ui_textual import (
     TitleBar,
     MetricCard,
@@ -21,6 +22,7 @@ from gengowatcher.ui_textual import (
     ConfigPreview,
     SessionStats as SessionStatsWidget,
     StatsPanel,
+    TelemetryPanel,
     GengoWatcherApp,
     TextualLogHandler,
     Icons,
@@ -808,6 +810,73 @@ class TestGengoWatcherApp:
         assert hasattr(app, "BINDINGS")
         assert len(app.BINDINGS) > 0
 
+    def test_setup_logging_attaches_handler_to_watcher_logger(
+        self, mock_config, mock_state, mock_watcher, mock_stats
+    ):
+        watcher_logger = logging.getLogger("test_ui_textual_comprehensive_app")
+        watcher_logger.handlers = []
+        watcher_logger.propagate = False
+        mock_watcher.logger = watcher_logger
+
+        app = GengoWatcherApp(
+            config=mock_config, state=mock_state, watcher=mock_watcher, stats=mock_stats
+        )
+
+        try:
+            app._setup_logging()
+            assert app._textual_log_handler in watcher_logger.handlers
+            assert app._logging_attached is True
+        finally:
+            app.on_unmount()
+
+        assert app._textual_log_handler not in watcher_logger.handlers
+        assert mock_watcher.on_job_added_callback is None
+
+    def test_on_mount_replays_buffered_startup_logs(
+        self, mock_config, mock_state, mock_watcher, mock_stats
+    ):
+        watcher_logger = logging.getLogger("test_ui_textual_comprehensive_replay")
+        watcher_logger.handlers = []
+        watcher_logger.propagate = False
+        mock_watcher.logger = watcher_logger
+
+        buffered_handler = UILoggingHandler()
+        record = logging.LogRecord(
+            "gengowatcher",
+            logging.INFO,
+            __file__,
+            1,
+            "WebSocket: Connection established and authenticated.",
+            (),
+            None,
+        )
+        buffered_handler.emit(record)
+
+        app = GengoWatcherApp(
+            config=mock_config,
+            state=mock_state,
+            watcher=mock_watcher,
+            stats=mock_stats,
+            ui_log_handler=buffered_handler,
+        )
+        app._setup_jobs_table = MagicMock()
+        app._refresh_dashboard_panels = MagicMock()
+        app.set_interval = MagicMock()
+        app._textual_log_handler._write_to_log = MagicMock()
+
+        try:
+            app.on_mount()
+
+            replay_calls = app._textual_log_handler._write_to_log.call_args_list
+            assert replay_calls
+            assert replay_calls[0].args[0] == "#activity-log"
+            assert replay_calls[1].args[0] == "#activity-log-full"
+            assert "WebSocket: Connection established and authenticated." in str(
+                replay_calls[0].args[1]
+            )
+        finally:
+            app.on_unmount()
+
     def test_refresh_dashboard_panels_dispatches_widget_refreshes(
         self, mock_config, mock_state, mock_watcher, mock_stats
     ):
@@ -821,7 +890,7 @@ class TestGengoWatcherApp:
             (MetricsRow, "refresh_metrics"),
             (JobsPreview, "refresh_jobs"),
             (HourlyActivity, "refresh_hourly"),
-            (SessionStatsWidget, "refresh_stats"),
+            (TelemetryPanel, "refresh_telemetry"),
         ]
 
         assert app._dashboard_refresh_targets() == expected_targets

--- a/tests/test_watcher_comprehensive.py
+++ b/tests/test_watcher_comprehensive.py
@@ -148,14 +148,13 @@ class TestWatcherInitialization:
             "gengowatcher.watcher.fetch_browser_session_snapshot_sync",
             return_value=MagicMock(
                 session_token="fresh-browser-token",
-                user_key="fresh-browser-user-key",
             ),
         ):
             GengoWatcher(mock_config, mock_state, logger)
 
         warning_messages = [str(call.args[0]) for call in logger.warning.call_args_list]
         assert any(
-            "credentials differ from the live browser session" in message
+            "user_session differs from the live browser session" in message
             for message in warning_messages
         )
 
@@ -197,7 +196,6 @@ class TestWatcherInitialization:
             "gengowatcher.watcher.fetch_browser_session_snapshot_sync",
             return_value=MagicMock(
                 session_token="fresh-token",
-                user_key="fresh-user-key",
                 user_agent="Helium Browser",
                 accept_language="en-GB,en-US;q=0.9",
             ),
@@ -207,9 +205,6 @@ class TestWatcherInitialization:
         assert changed is True
         watcher_instance.config.set.assert_any_call(
             "WebSocket", "user_session", "fresh-token"
-        )
-        watcher_instance.config.set.assert_any_call(
-            "WebSocket", "user_key", "fresh-user-key"
         )
         watcher_instance.config.set.assert_any_call(
             "Network", "browser_user_agent", "Helium Browser"
@@ -245,12 +240,42 @@ class TestWatcherInitialization:
         assert watcher_instance._websocket_sync_failed is True
         watcher_instance.show_notification.assert_called_once()
 
+    def test_sync_session_from_browser_fail_hard_falls_back_to_cached_credentials(
+        self, watcher_instance
+    ):
+        """Cached websocket auth should keep realtime alive when browser sync is flaky."""
+        watcher_instance.config.get.side_effect = lambda s, k, **kw: {
+            ("WebSocket", "browser_debug_url"): "http://127.0.0.1:9222",
+            ("WebSocket", "user_session"): "cached-session-token",
+            ("WebSocket", "user_id"): 12345,
+        }.get(
+            (s, k), watcher_instance.config.config.get(s, {}).get(k, kw.get("fallback"))
+        )
+        watcher_instance.show_notification = MagicMock()
+
+        with patch(
+            "gengowatcher.watcher.fetch_browser_session_snapshot_sync",
+            side_effect=RuntimeError("browser gone"),
+        ):
+            changed = watcher_instance._sync_session_from_browser(
+                fail_hard=True,
+                alert_on_failure=True,
+            )
+
+        assert changed is False
+        assert watcher_instance._websocket_sync_failed is False
+        assert watcher_instance._websocket_sync_failure_reason is None
+        assert watcher_instance.websocket_status != "Session Sync Failed"
+        watcher_instance.show_notification.assert_not_called()
+
     def test_sync_session_from_browser_uses_dedicated_failure_sound_override(
         self, watcher_instance
     ):
         """Browser sync failures should use the dedicated sound override when set."""
+        watcher_instance.show_notification = MagicMock()
         watcher_instance.config.get.side_effect = lambda s, k, **kw: {
             ("WebSocket", "browser_debug_url"): "http://127.0.0.1:9222",
+            ("WebSocket", "user_session"): "REPLACE_WITH_YOUR_SESSION_TOKEN",
             ("Paths", "browser_session_sync_failed_sound_file"): "assets/sync-failed.wav",
         }.get(
             (s, k), watcher_instance.config.config.get(s, {}).get(k, kw.get("fallback"))
@@ -258,12 +283,7 @@ class TestWatcherInitialization:
 
         with patch(
             "gengowatcher.watcher.fetch_browser_session_snapshot_sync",
-            return_value=MagicMock(
-                session_token="fresh-token",
-                user_key="",
-                user_agent="Helium Browser",
-                accept_language="en-GB,en-US;q=0.9",
-            ),
+            side_effect=RuntimeError("browser gone"),
         ):
             changed = watcher_instance._sync_session_from_browser(
                 fail_hard=False,
@@ -278,10 +298,10 @@ class TestWatcherInitialization:
             sound_file="assets/sync-failed.wav",
         )
 
-    def test_sync_session_from_browser_clears_placeholder_user_key_when_missing(
+    def test_sync_session_from_browser_does_not_touch_user_key(
         self, watcher_instance
     ):
-        """Browser sync should remove placeholder keys when the live browser has none."""
+        """Browser sync should remain session-only and leave user_key untouched."""
         watcher_instance.config.get.side_effect = lambda s, k, **kw: {
             ("WebSocket", "browser_debug_url"): "http://127.0.0.1:9222",
             ("WebSocket", "user_session"): "fresh-token",
@@ -294,7 +314,6 @@ class TestWatcherInitialization:
             "gengowatcher.watcher.fetch_browser_session_snapshot_sync",
             return_value=MagicMock(
                 session_token="fresh-token",
-                user_key="",
                 user_agent="Helium Browser",
                 accept_language="en-GB,en-US;q=0.9",
             ),
@@ -302,7 +321,10 @@ class TestWatcherInitialization:
             changed = watcher_instance._sync_session_from_browser()
 
         assert changed is True
-        watcher_instance.config.set.assert_any_call("WebSocket", "user_key", "")
+        assert (
+            ("WebSocket", "user_key", "")
+            not in [call.args for call in watcher_instance.config.set.call_args_list]
+        )
 
     def test_get_effective_rss_wait_range_uses_randomized_gengo_window(
         self, watcher_instance
@@ -537,10 +559,10 @@ class TestWatcherInitialization:
         assert watcher_instance._next_quiet_socket_sync_ts == 1350.0
         mock_sync.assert_called_once_with(fail_hard=False, alert_on_failure=False)
 
-    def test_get_health_snapshot_marks_quiet_live_websocket_stale(
+    def test_get_health_snapshot_keeps_quiet_live_websocket_healthy(
         self, watcher_instance
     ):
-        """A live socket with fresh pongs but no messages for too long should look stale."""
+        """A live socket with fresh pongs should stay healthy even if the feed is quiet."""
         watcher_instance.websocket_status = "Live"
         watcher_instance.websocket_connected_at_ts = 999_600.0
         watcher_instance.websocket_last_message_ts = None
@@ -582,8 +604,8 @@ class TestWatcherInitialization:
 
         health = watcher_instance.get_health_snapshot(now=1_000_000.0)
 
-        assert health["websocket"]["state"] == "stale"
-        assert health["websocket"]["detail"] == "quiet 400s"
+        assert health["websocket"]["state"] == "healthy"
+        assert health["websocket"]["detail"] == "ok"
         assert health["websocket"]["quiet_age_sec"] == 400.0
 
     def test_initialization_validates_check_interval(

--- a/tests/test_web_comprehensive.py
+++ b/tests/test_web_comprehensive.py
@@ -233,6 +233,26 @@ class TestWebAPIInitialization:
                 mock_watcher_class.assert_called_once()
                 mock_thread.assert_called_once()
 
+    def test_web_api_reuses_shared_watcher_without_starting_thread(
+        self, mock_config, mock_state, mock_logger
+    ):
+        """Shared watcher mode must not create a duplicate monitor thread."""
+        shared_watcher = MagicMock()
+
+        with patch("gengowatcher.web.GengoWatcher") as mock_watcher_class:
+            with patch("threading.Thread") as mock_thread:
+                api = WebAPI(
+                    mock_config,
+                    mock_state,
+                    mock_logger,
+                    watcher=shared_watcher,
+                    start_watcher_thread=False,
+                )
+
+        assert api.watcher is shared_watcher
+        mock_watcher_class.assert_not_called()
+        mock_thread.assert_not_called()
+
     def test_web_api_thread_safety_locks(self, mock_config, mock_state, mock_logger):
         """Test that thread safety locks are created."""
         with patch("gengowatcher.web.GengoWatcher"):
@@ -240,6 +260,23 @@ class TestWebAPIInitialization:
             assert hasattr(api, "_status_lock")
             assert hasattr(api, "_connections_lock")
             assert hasattr(api, "_jobs_lock")
+
+    def test_shutdown_does_not_stop_shared_watcher(
+        self, mock_config, mock_state, mock_logger
+    ):
+        """Runtime-owned watchers should not be shut down by the web wrapper."""
+        shared_watcher = MagicMock()
+        api = WebAPI(
+            mock_config,
+            mock_state,
+            mock_logger,
+            watcher=shared_watcher,
+            start_watcher_thread=False,
+        )
+
+        api.shutdown()
+
+        shared_watcher.handle_exit.assert_not_called()
 
 
 class TestWebAPIStatus:

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -87,8 +87,8 @@ async def test_websocket_receives_and_processes_job(mock_connect, watcher_instan
     """
     Test that a valid job received from the WebSocket is correctly processed.
 
-    The websocket auth payload should mirror the browser-aligned credentials
-    available in config, including user_key when present.
+    The websocket handshake should send the browser-aligned session headers and
+    the auth payload should use the session token.
     """
     w = watcher_instance
     job_payload = {
@@ -115,7 +115,13 @@ async def test_websocket_receives_and_processes_job(mock_connect, watcher_instan
         else "extra_headers"
     )
     assert kwargs[header_key] is not None
-    assert "Cookie" not in kwargs[header_key]
+    assert kwargs[header_key]["Cookie"] == (
+        "myG_myGSession_=fake_session_token; myG_rdsessID=fake_session_token"
+    )
+    assert kwargs[header_key]["User-Agent"] == (
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36"
+    )
     assert kwargs[header_key]["Accept-Language"] == "en-GB,en-US;q=0.9,en;q=0.8"
     assert kwargs["ping_interval"] == 20
     assert kwargs["ping_timeout"] == 10
@@ -123,7 +129,7 @@ async def test_websocket_receives_and_processes_job(mock_connect, watcher_instan
     auth_call = mock_ws_client.send.await_args[0][0]
     assert '"user_id": 12345' in auth_call
     assert '"user_session": "fake_session_token"' in auth_call
-    assert '"user_key": "fake_browser_user_key"' in auth_call
+    assert '"user_key"' not in auth_call
     w._process_new_job.assert_called_once_with(
         9876,
         "English > Japanese",
@@ -152,7 +158,9 @@ async def test_websocket_retries_with_ua_only_after_handshake_timeout(
     assert len(connect_factory.calls) == 2
     first_kwargs = connect_factory.calls[0][1]
     second_kwargs = connect_factory.calls[1][1]
-    assert "Cookie" not in first_kwargs["additional_headers"]
+    assert first_kwargs["additional_headers"]["Cookie"] == (
+        "myG_myGSession_=fake_session_token; myG_rdsessID=fake_session_token"
+    )
     assert second_kwargs["additional_headers"] == {
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36"
     }


### PR DESCRIPTION
## What changed
- align websocket browser-session discovery, handshake headers, and auth payload with the live Gengo browser state
- add lightweight CLI session check/sync commands and improve watcher behavior for quiet realtime sockets
- share the runtime-owned watcher with the web server/TUI path, replay buffered UI logs on mount, and persist the selected theme
- harden web file storage path handling while preserving safe filenames used by uploaded artifacts

## Why
The realtime path and the runtime/web path were both carrying stale assumptions:
- websocket auth was still treating `user_key` as part of the contract and wasn't mirroring the browser handshake closely enough
- starting the web server alongside the TUI could create duplicate watcher ownership/lifecycle issues
- the recent file-path hardening accidentally rejected generated filenames that include decimal value components

## Impact
- realtime websocket connections use browser-aligned cookie/auth behavior and recover more gracefully when the feed stays quiet
- `--sync-session-from-browser` and `--check-session-from-browser` can run as lightweight config commands
- the web API can reuse the runtime watcher instead of starting a duplicate monitor thread
- uploaded file entries round-trip correctly again in the web API

## Validation
- `.venv/bin/python -m pytest tests/test_browser_session.py tests/test_websocket.py tests/test_watcher_comprehensive.py -q`
- `.venv/bin/python -m pytest tests/test_cli.py tests/test_main.py tests/test_ui_textual_components.py tests/test_ui_textual_comprehensive.py -q`
- `python3 -m pytest tests/test_web_comprehensive.py -q`
- `.venv/bin/python -m py_compile src/gengowatcher/*.py tests/*.py scripts/*.py`
