### PR TITLE
Port useful PR109 runtime and web fixes

### DIFF
--- a/src/gengowatcher/runtime.py
+++ b/src/gengowatcher/runtime.py
@@ -51,11 +51,18 @@ def run_application(args: argparse.Namespace, console: Console) -> None:
         )
         watcher.prompt_for_config_values()
 
-    web_thread = _start_web_server_if_requested(args, console)
+    web_thread = _start_web_server_if_requested(
+        args,
+        console,
+        config=config,
+        state=state,
+        logger=log,
+        watcher=watcher,
+    )
     if args.web_only:
         _run_web_only(console, web_thread)
 
-    _run_tui(args, console, log, config, state, watcher)
+    _run_tui(args, console, log, ui_handler, config, state, watcher)
 
 
 def _start_metrics_server_if_enabled(
@@ -108,7 +115,13 @@ def _handle_setup_commands(
 
 
 def _start_web_server_if_requested(
-    args: argparse.Namespace, console: Console
+    args: argparse.Namespace,
+    console: Console,
+    *,
+    config: AppConfig,
+    state: AppState,
+    logger: logging.Logger,
+    watcher: GengoWatcher,
 ) -> threading.Thread | None:
     if not (args.web or args.web_only):
         return None
@@ -118,7 +131,15 @@ def _start_web_server_if_requested(
 
         def start_web_server():
             print(f"Starting web server on http://127.0.0.1:{args.web_port}")
-            run_web_server(host="127.0.0.1", port=args.web_port)
+            run_web_server(
+                host="127.0.0.1",
+                port=args.web_port,
+                config=config,
+                state=state,
+                logger=logger,
+                watcher=watcher,
+                start_watcher_thread=bool(args.web_only),
+            )
 
         web_thread = threading.Thread(
             target=start_web_server, daemon=True, name="WebServerThread"
@@ -147,6 +168,7 @@ def _run_tui(
     args: argparse.Namespace,
     console: Console,
     log: logging.Logger,
+    ui_handler: logging.Handler,
     config: AppConfig,
     state: AppState,
     watcher: GengoWatcher,
@@ -157,6 +179,7 @@ def _run_tui(
         config=config,
         state=state,
         stats=stats_manager,
+        ui_log_handler=ui_handler,
     )
 
     watcher_thread = threading.Thread(

--- a/src/gengowatcher/ui_textual.py
+++ b/src/gengowatcher/ui_textual.py
@@ -32,6 +32,7 @@ from textual.widgets import (
 )
 
 from .config import AppConfig
+from .logging_setup import UILoggingHandler
 from .state import AppState
 from .stats import StatsManager
 from .watcher import TIER_UNIT_RATES, GengoWatcher
@@ -2106,12 +2107,14 @@ class GengoWatcherApp(App):
         state: AppState,
         watcher: GengoWatcher,
         stats: StatsManager,
+        ui_log_handler: UILoggingHandler | None = None,
     ):
         super().__init__()
         self.config = config
         self.state = state
         self.watcher = watcher
         self.stats = stats
+        self._ui_log_handler = ui_log_handler
         self._initializing_theme = True
         self._persist_theme_changes = True
         self.theme = self._configured_theme_name()
@@ -2125,6 +2128,7 @@ class GengoWatcherApp(App):
         )
         self._logging_attached = False
         self._job_added_callback = self._on_job_added_from_thread
+        self._buffered_logs_replayed = False
 
         # Register callback for when new jobs are detected
         self.watcher.on_job_added_callback = self._job_added_callback
@@ -2218,6 +2222,19 @@ class GengoWatcherApp(App):
         self._log_source.addHandler(self._textual_log_handler)
         self._logging_attached = True
 
+    def _replay_buffered_logs(self) -> None:
+        if self._buffered_logs_replayed or self._ui_log_handler is None:
+            return
+
+        queued_logs = list(getattr(self._ui_log_handler, "log_queue", ()))
+        for entry in queued_logs:
+            if not isinstance(entry, Text):
+                continue
+            self._textual_log_handler.append_log("#activity-log", entry)
+            self._textual_log_handler.append_log("#activity-log-full", entry)
+
+        self._buffered_logs_replayed = True
+
     def on_unmount(self) -> None:
         """Detach callbacks and log handlers owned by this app instance."""
         current_callback = getattr(self.watcher, "on_job_added_callback", None)
@@ -2230,6 +2247,7 @@ class GengoWatcherApp(App):
     def on_mount(self) -> None:
         """Initialize the jobs table with columns when the app mounts."""
         self._setup_logging()
+        self._replay_buffered_logs()
         self._refresh_responsive_layout()
         self.call_after_refresh(self._refresh_responsive_layout)
         self._setup_jobs_table()
@@ -2569,6 +2587,10 @@ class TextualLogHandler(logging.Handler):
             log.write(colored_text)
         except NoMatches:
             pass  # Widget not mounted yet
+
+    def append_log(self, widget_id: str, colored_text: Text) -> None:
+        """Append an already formatted log entry to a specific log widget."""
+        self._write_to_log(widget_id, colored_text)
 
     def write_log(self, msg: str, level: int = logging.INFO):
         colored_text = self._colorize_message(msg, level)

--- a/src/gengowatcher/web.py
+++ b/src/gengowatcher/web.py
@@ -322,19 +322,15 @@ class WebAPI:
         # Accept only a single filename component (no user-influenced subpaths).
         candidate_path = Path(path)
         if candidate_path.is_absolute():
-            candidate_name = candidate_path.name
-        else:
-            candidate_name = candidate_path.name
-            if candidate_path != Path(candidate_name):
-                raise ValueError("Invalid stored filename")
+            raise ValueError("Absolute paths are not allowed")
+        candidate_name = candidate_path.name
+        if candidate_path != Path(candidate_name):
+            raise ValueError("Invalid stored filename")
         if candidate_name in {"", ".", ".."}:
             raise ValueError("Invalid stored filename")
 
         try:
-            if candidate_path.is_absolute():
-                resolved = candidate_path.resolve(strict=False)
-            else:
-                resolved = (storage_dir / candidate_name).resolve(strict=False)
+            resolved = (storage_dir / candidate_name).resolve(strict=False)
         except OSError as exc:
             raise ValueError("Invalid path in configured storage directory") from exc
 

--- a/src/gengowatcher/web.py
+++ b/src/gengowatcher/web.py
@@ -201,38 +201,52 @@ class StoredFileUploadResponse(BaseModel):
 class WebAPI:
     """Web API wrapper for GengoWatcher that maintains thread safety."""
 
-    def __init__(self, config: AppConfig, state: AppState, logger: logging.Logger):
+    def __init__(
+        self,
+        config: AppConfig,
+        state: AppState,
+        logger: logging.Logger,
+        *,
+        watcher: Optional[GengoWatcher] = None,
+        start_watcher_thread: bool = True,
+    ):
         """Initialize the WebAPI instance.
 
-        Creates a separate GengoWatcher instance for the web API to avoid conflicts
-        with the TUI. Sets up thread safety mechanisms and starts the watcher thread.
+        Uses a shared watcher when provided, otherwise creates its own watcher.
+        This allows the web API to run alongside the TUI without starting a
+        duplicate RSS/WebSocket monitor loop.
 
         Args:
             config: Application configuration object.
             state: Application state object for data persistence.
             logger: Logger instance for recording events.
+            watcher: Optional shared watcher instance owned by the runtime.
+            start_watcher_thread: Whether this WebAPI instance should start and
+                manage the watcher thread lifecycle.
         """
         self.config = config
         self.state = state
         self.logger = logger
-
-        # Create a separate watcher instance for web API
-        # This allows web UI to run alongside TUI without conflicts
-        self.watcher = GengoWatcher(config, state, logger)
+        self._manage_watcher_lifecycle = start_watcher_thread
+        self.watcher = (
+            watcher if watcher is not None else GengoWatcher(config, state, logger)
+        )
 
         # Thread safety for shared state access
         self._status_lock = threading.RLock()  # Reentrant lock for better safety
         self._active_connections: List[WebSocket] = []
         self._connections_lock = threading.RLock()
         self._jobs_lock = threading.RLock()
+        self.watcher_thread: Optional[threading.Thread] = None
 
-        # Start the watcher in a separate thread
-        self.watcher_thread = threading.Thread(
-            target=self.watcher.run, daemon=True, name="WebWatcherThread"
-        )
-        self.watcher_thread.start()
-
-        self.logger.info("WebAPI initialized and watcher thread started")
+        if start_watcher_thread:
+            self.watcher_thread = threading.Thread(
+                target=self.watcher.run, daemon=True, name="WebWatcherThread"
+            )
+            self.watcher_thread.start()
+            self.logger.info("WebAPI initialized and watcher thread started")
+        else:
+            self.logger.info("WebAPI initialized using shared watcher instance")
 
     def get_status(self) -> WatcherStatus:
         """Get current watcher status."""
@@ -307,14 +321,20 @@ class WebAPI:
 
         # Accept only a single filename component (no user-influenced subpaths).
         candidate_path = Path(path)
-        candidate_name = candidate_path.name
+        if candidate_path.is_absolute():
+            candidate_name = candidate_path.name
+        else:
+            candidate_name = candidate_path.name
+            if candidate_path != Path(candidate_name):
+                raise ValueError("Invalid stored filename")
         if candidate_name in {"", ".", ".."}:
-            raise ValueError("Invalid stored filename")
-        if candidate_path != Path(candidate_name):
             raise ValueError("Invalid stored filename")
 
         try:
-            resolved = (storage_dir / candidate_name).resolve(strict=False)
+            if candidate_path.is_absolute():
+                resolved = candidate_path.resolve(strict=False)
+            else:
+                resolved = (storage_dir / candidate_name).resolve(strict=False)
         except OSError as exc:
             raise ValueError("Invalid path in configured storage directory") from exc
 
@@ -900,11 +920,13 @@ class WebAPI:
     def shutdown(self):
         """Shutdown the web API and watcher."""
         self.logger.info("Shutting down WebAPI")
-        self.watcher.handle_exit()
+        if self._manage_watcher_lifecycle:
+            self.watcher.handle_exit()
 
 
 # Global API instance
 api_instance: Optional[WebAPI] = None
+shared_runtime_context: Optional[Dict[str, Any]] = None
 
 
 PROM_API_INITIALIZED = Gauge(
@@ -921,28 +943,40 @@ ensure_watcher_metrics_registered(
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """FastAPI lifespan context manager."""
-    global api_instance
+    global api_instance, shared_runtime_context
 
     # Startup
     logger = logging.getLogger("gengowatcher.web")
     try:
-        # Check if config exists, create it if needed
-        from pathlib import Path
-
-        config_path = Path(AppConfig.CONFIG_FILE)
-        if not config_path.exists():
-            logger.info("Creating default %s for web API", AppConfig.CONFIG_FILE)
-            config_path.write_text(
-                AppConfig._dump_toml(AppConfig.DEFAULT_CONFIG),
-                encoding="utf-8",
+        runtime_context = shared_runtime_context
+        shared_watcher = None
+        start_watcher_thread = True
+        if runtime_context:
+            config = runtime_context["config"]
+            state = runtime_context["state"]
+            logger = runtime_context.get("logger") or logger
+            shared_watcher = runtime_context.get("watcher")
+            start_watcher_thread = bool(
+                runtime_context.get("start_watcher_thread", True)
             )
-            logger.info(
-                "Default config created. Please review %s before using the web API.",
-                AppConfig.CONFIG_FILE,
-            )
+        else:
+            # Check if config exists, create it if needed
+            from pathlib import Path
 
-        config = AppConfig()
-        state = AppState(logger=logger)
+            config_path = Path(AppConfig.CONFIG_FILE)
+            if not config_path.exists():
+                logger.info("Creating default %s for web API", AppConfig.CONFIG_FILE)
+                config_path.write_text(
+                    AppConfig._dump_toml(AppConfig.DEFAULT_CONFIG),
+                    encoding="utf-8",
+                )
+                logger.info(
+                    "Default config created. Please review %s before using the web API.",
+                    AppConfig.CONFIG_FILE,
+                )
+
+            config = AppConfig()
+            state = AppState(logger=logger)
 
         # Initialize authenticator with config token
         api_token = config.get("WebServer", "auth_token")
@@ -962,7 +996,13 @@ async def lifespan(app: FastAPI):
         global authenticator
         authenticator = APIAuthenticator(api_token)
 
-        api_instance = WebAPI(config, state, logger)
+        api_instance = WebAPI(
+            config,
+            state,
+            logger,
+            watcher=shared_watcher,
+            start_watcher_thread=start_watcher_thread,
+        )
         logger.info("WebAPI started successfully")
     except Exception as e:
         logger.exception(f"Failed to start WebAPI: {e}")
@@ -973,6 +1013,7 @@ async def lifespan(app: FastAPI):
     # Shutdown
     if api_instance:
         api_instance.shutdown()
+    shared_runtime_context = None
 
 
 # Create FastAPI app
@@ -1424,11 +1465,35 @@ async def serve_react_app(path: str):
         raise HTTPException(status_code=404, detail="React app not built yet")
 
 
-def run_web_server(host: str = "127.0.0.1", port: int = 8000):
+def run_web_server(
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    *,
+    config: Optional[AppConfig] = None,
+    state: Optional[AppState] = None,
+    logger: Optional[logging.Logger] = None,
+    watcher: Optional[GengoWatcher] = None,
+    start_watcher_thread: bool = True,
+):
     """Run the web server."""
-    uvicorn.run(
-        "gengowatcher.web:app", host=host, port=port, reload=False, log_level="info"
-    )
+    global shared_runtime_context
+    if (config is None) != (state is None):
+        raise ValueError("config and state must be supplied together")
+    if watcher is not None and (config is None or state is None):
+        raise ValueError("shared watcher requires config and state")
+
+    if config is not None and state is not None:
+        shared_runtime_context = {
+            "config": config,
+            "state": state,
+            "logger": logger,
+            "watcher": watcher,
+            "start_watcher_thread": start_watcher_thread,
+        }
+    else:
+        shared_runtime_context = None
+
+    uvicorn.run(app, host=host, port=port, reload=False, log_level="info")
 
 
 if __name__ == "__main__":

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,106 @@
+"""Tests for runtime-owned watcher sharing."""
+
+from argparse import Namespace
+from unittest.mock import MagicMock, patch
+
+from gengowatcher.runtime import _run_tui, _start_web_server_if_requested
+
+
+class _InlineThread:
+    def __init__(self, target, daemon=None, name=None):
+        self.target = target
+        self.daemon = daemon
+        self.name = name
+        self.started = False
+
+    def start(self):
+        self.started = True
+        self.target()
+
+    def join(self, timeout=None):
+        return None
+
+
+def test_start_web_server_reuses_runtime_watcher_for_tui_web_mode():
+    args = Namespace(web=True, web_only=False, web_port=37181)
+    config = MagicMock()
+    state = MagicMock()
+    logger = MagicMock()
+    watcher = MagicMock()
+
+    with (
+        patch("gengowatcher.web.run_web_server") as mock_run_web_server,
+        patch("gengowatcher.runtime.threading.Thread", _InlineThread),
+        patch("gengowatcher.runtime.time.sleep"),
+    ):
+        thread = _start_web_server_if_requested(
+            args,
+            MagicMock(),
+            config=config,
+            state=state,
+            logger=logger,
+            watcher=watcher,
+        )
+
+    assert isinstance(thread, _InlineThread)
+    mock_run_web_server.assert_called_once_with(
+        host="127.0.0.1",
+        port=37181,
+        config=config,
+        state=state,
+        logger=logger,
+        watcher=watcher,
+        start_watcher_thread=False,
+    )
+
+
+def test_start_web_server_starts_runtime_watcher_for_web_only_mode():
+    args = Namespace(web=False, web_only=True, web_port=37181)
+    config = MagicMock()
+    state = MagicMock()
+    logger = MagicMock()
+    watcher = MagicMock()
+
+    with (
+        patch("gengowatcher.web.run_web_server") as mock_run_web_server,
+        patch("gengowatcher.runtime.threading.Thread", _InlineThread),
+        patch("gengowatcher.runtime.time.sleep"),
+    ):
+        _start_web_server_if_requested(
+            args,
+            MagicMock(),
+            config=config,
+            state=state,
+            logger=logger,
+            watcher=watcher,
+        )
+
+    assert mock_run_web_server.call_args.kwargs["start_watcher_thread"] is True
+
+
+def test_run_tui_passes_buffered_ui_log_handler_to_app():
+    args = Namespace()
+    console = MagicMock()
+    logger = MagicMock()
+    ui_handler = MagicMock()
+    config = MagicMock()
+    state = MagicMock()
+    watcher = MagicMock()
+    watcher.shutdown_event.is_set.return_value = False
+
+    with (
+        patch("gengowatcher.runtime.StatsManager") as mock_stats_manager,
+        patch("gengowatcher.runtime.GengoWatcherApp") as mock_app_class,
+        patch("gengowatcher.runtime.threading.Thread") as mock_thread,
+    ):
+        _run_tui(args, console, logger, ui_handler, config, state, watcher)
+
+    mock_app_class.assert_called_once_with(
+        watcher=watcher,
+        config=config,
+        state=state,
+        stats=mock_stats_manager.return_value,
+        ui_log_handler=ui_handler,
+    )
+    mock_thread.return_value.start.assert_called_once()
+    mock_app_class.return_value.run.assert_called_once()

--- a/tests/test_ui_textual_comprehensive.py
+++ b/tests/test_ui_textual_comprehensive.py
@@ -29,6 +29,7 @@ from gengowatcher.ui_textual import (
     _with_timestamp_prefix,
     BAR_CHARS,
 )
+from gengowatcher.logging_setup import UILoggingHandler
 from gengowatcher.stats import StatsManager
 from textual.css.query import NoMatches
 from textual.theme import Theme
@@ -797,6 +798,49 @@ class TestGengoWatcherApp:
 
         mock_config.set.assert_called_with("UI", "theme_name", "gruvbox")
         mock_config.save_config.assert_called_once()
+
+    def test_on_mount_replays_buffered_startup_logs(
+        self, mock_config, mock_state, mock_watcher, mock_stats
+    ):
+        buffered_handler = UILoggingHandler()
+        record = logging.LogRecord(
+            "gengowatcher",
+            logging.INFO,
+            __file__,
+            1,
+            "WebSocket: Connection established and authenticated.",
+            (),
+            None,
+        )
+        buffered_handler.emit(record)
+
+        app = GengoWatcherApp(
+            config=mock_config,
+            state=mock_state,
+            watcher=mock_watcher,
+            stats=mock_stats,
+            ui_log_handler=buffered_handler,
+        )
+        app._refresh_responsive_layout = MagicMock()
+        app.call_after_refresh = MagicMock()
+        app._setup_jobs_table = MagicMock()
+        app._refresh_dashboard_panels = MagicMock()
+        app.set_interval = MagicMock()
+        app._textual_log_handler.append_log = MagicMock()
+
+        try:
+            app.on_mount()
+
+            replay_calls = app._textual_log_handler.append_log.call_args_list
+            assert len(replay_calls) == 2
+            assert replay_calls[0].args[0] == "#activity-log"
+            assert replay_calls[1].args[0] == "#activity-log-full"
+            assert "WebSocket: Connection established and authenticated." in str(
+                replay_calls[0].args[1]
+            )
+            assert app._buffered_logs_replayed is True
+        finally:
+            app.on_unmount()
 
     @pytest.mark.asyncio
     async def test_app_has_bindings(

--- a/tests/test_web_comprehensive.py
+++ b/tests/test_web_comprehensive.py
@@ -15,7 +15,9 @@ from gengowatcher.web import (
     ConfigSection,
     CommandRequest,
     PaginationParams,
+    run_web_server,
 )
+import gengowatcher.web as web_module
 from gengowatcher.config import AppConfig
 from gengowatcher.state import AppState
 
@@ -232,6 +234,85 @@ class TestWebAPIInitialization:
                 assert api.logger == mock_logger
                 mock_watcher_class.assert_called_once()
                 mock_thread.assert_called_once()
+
+    def test_web_api_reuses_shared_watcher_without_starting_thread(
+        self, mock_config, mock_state, mock_logger
+    ):
+        """Shared watcher mode must not create a duplicate monitor thread."""
+        shared_watcher = MagicMock()
+
+        with patch("gengowatcher.web.GengoWatcher") as mock_watcher_class:
+            with patch("threading.Thread") as mock_thread:
+                api = WebAPI(
+                    mock_config,
+                    mock_state,
+                    mock_logger,
+                    watcher=shared_watcher,
+                    start_watcher_thread=False,
+                )
+
+        assert api.watcher is shared_watcher
+        mock_watcher_class.assert_not_called()
+        mock_thread.assert_not_called()
+
+    def test_shutdown_does_not_stop_shared_watcher(
+        self, mock_config, mock_state, mock_logger
+    ):
+        """Runtime-owned watchers should not be shut down by the web wrapper."""
+        shared_watcher = MagicMock()
+        api = WebAPI(
+            mock_config,
+            mock_state,
+            mock_logger,
+            watcher=shared_watcher,
+            start_watcher_thread=False,
+        )
+
+        api.shutdown()
+
+        shared_watcher.handle_exit.assert_not_called()
+
+    def test_run_web_server_requires_complete_runtime_context(
+        self, mock_config, mock_state
+    ):
+        with pytest.raises(ValueError, match="config and state"):
+            run_web_server(config=mock_config)
+
+        with pytest.raises(ValueError, match="config and state"):
+            run_web_server(state=mock_state)
+
+    def test_run_web_server_stores_shared_runtime_context(
+        self, mock_config, mock_state, mock_logger
+    ):
+        shared_watcher = MagicMock()
+        try:
+            with patch("gengowatcher.web.uvicorn.run") as mock_uvicorn_run:
+                run_web_server(
+                    host="127.0.0.1",
+                    port=37181,
+                    config=mock_config,
+                    state=mock_state,
+                    logger=mock_logger,
+                    watcher=shared_watcher,
+                    start_watcher_thread=False,
+                )
+
+            assert web_module.shared_runtime_context == {
+                "config": mock_config,
+                "state": mock_state,
+                "logger": mock_logger,
+                "watcher": shared_watcher,
+                "start_watcher_thread": False,
+            }
+            mock_uvicorn_run.assert_called_once_with(
+                web_module.app,
+                host="127.0.0.1",
+                port=37181,
+                reload=False,
+                log_level="info",
+            )
+        finally:
+            web_module.shared_runtime_context = None
 
     def test_web_api_thread_safety_locks(self, mock_config, mock_state, mock_logger):
         """Test that thread safety locks are created."""


### PR DESCRIPTION
  - Shared runtime watcher wiring for TUI + web mode, avoiding a duplicate web watcher.
  - Web-only still starts/manages the runtime-created watcher through WebAPI.
  - TUI startup log replay from the buffered UILoggingHandler.
  - A narrow fix to web file storage containment so safe generated paths round-trip without weakening path escape checks.
