### PR TITLE
Potential fix for code scanning alert no. 50: Uncontrolled data used in path expression

### DIFF
--- a/src/gengowatcher/web_file_storage.py
+++ b/src/gengowatcher/web_file_storage.py
@@ -248,15 +248,17 @@ class WebFileStorage:
         )
         if not self.is_valid_stored_name(safe_name):
             raise ValueError("Invalid stored filename")
-        destination = self.ensure_within_storage_dir(storage_dir / safe_name)
+        safe_leaf_name = Path(safe_name).name
+        destination = self.ensure_within_storage_dir(storage_dir / safe_leaf_name)
         counter = 1
         while destination.exists():
-            stem = Path(safe_name).stem
-            suffix = Path(safe_name).suffix
+            stem = Path(safe_leaf_name).stem
+            suffix = Path(safe_leaf_name).suffix
             candidate_name = f"{stem}-{counter}{suffix}"
             if not self.is_valid_stored_name(candidate_name):
                 raise ValueError("Invalid stored filename")
-            destination = self.ensure_within_storage_dir(storage_dir / candidate_name)
+            candidate_leaf_name = Path(candidate_name).name
+            destination = self.ensure_within_storage_dir(storage_dir / candidate_leaf_name)
             counter += 1
         metadata = {
             "original_name": filename or destination.name,


### PR DESCRIPTION
Potential fix for [https://github.com/tdawe1/GengoWatcher/security/code-scanning/50](https://github.com/tdawe1/GengoWatcher/security/code-scanning/50)

To fix this without changing functionality, harden the final path construction point in `save_uploaded_file` so only a strict basename is ever used when forming `destination` and collision candidates.

Best single approach:
- In `src/gengowatcher/web_file_storage.py`, inside `save_uploaded_file`, normalize `safe_name` and `candidate_name` to `Path(...).name` right before joining with `storage_dir`.
- Keep existing validation (`is_valid_stored_name`) and containment (`ensure_within_storage_dir`) intact.
- This creates an explicit final guard against any path component injection and helps static analyzers understand that only filename leaf components are used.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
